### PR TITLE
add getExport method

### DIFF
--- a/.changeset/young-beers-lick.md
+++ b/.changeset/young-beers-lick.md
@@ -1,0 +1,12 @@
+---
+'renoun': major
+---
+
+Removes `getDefaultExport` and `getNamedExport` from collection export sources in favor of a new `getExport` method. This method works exactly the same as the previous `getNamedExport` method with the addition of accepting `default` as an export. This simplifies the API and reduces the number of methods needed to query an export source.
+
+### Breaking Changes
+
+Update any usage of `getDefaultExport` and `getNamedExport` to use the new `getExport` method:
+
+- `getDefaultExport()` -> `getExport('default')`
+- `getNamedExport('metadata')` -> `getExport('metadata')`

--- a/apps/site/app/(site)/collections/docs/recipes.mdx
+++ b/apps/site/app/(site)/collections/docs/recipes.mdx
@@ -39,8 +39,8 @@ export default async function Page({ params }: { params: { slug: string } }) {
 
   if (!Post) notFound()
 
-  const frontmatter = await Post.getNamedExport('frontmatter').getValue()
-  const Content = await Post.getDefaultExport().getValue()
+  const frontmatter = await Post.getExport('frontmatter').getValue()
+  const Content = await Post.getExport('default').getValue()
 
   return (
     <>
@@ -109,7 +109,7 @@ export default async function Page({
   // Retrieve the frontmatter for sorting
   const sourcesWithfrontmatter = await Promise.all(
     allSources.map(async (source) => {
-      const frontmatter = await source.getNamedExport('frontmatter').getValue()
+      const frontmatter = await source.getExport('frontmatter').getValue()
       return { source, frontmatter }
     })
   )
@@ -174,7 +174,7 @@ async function TreeNavigation({ source }: { source: PostSource }) {
   const sources = source.getSources()
   const path = source.getPath()
   const depth = source.getDepth()
-  const frontmatter = await source.getNamedExport('frontmatter').getValue()
+  const frontmatter = await source.getExport('frontmatter').getValue()
 
   if (sources.length === 0) {
     return (
@@ -215,8 +215,8 @@ export default async function Page({ params }) {
 
   if (!source) notFound()
 
-  const Post = await source.getDefaultExport().getValue()
-  const frontmatter = await source.getNamedExport('frontmatter').getValue()
+  const frontmatter = await source.getExport('frontmatter').getValue()
+  const Post = await source.getExport('default').getValue()
   const [previous, next] = source.getSiblings()
 
   return (
@@ -237,7 +237,7 @@ function Sibling({
   source: PostsSource
   direction: 'previous' | 'next'
 }) {
-  const frontmatter = await source.getNamedExport('frontmatter').getValue()
+  const frontmatter = await source.getExport('frontmatter').getValue()
 
   return (
     <a href={source.getPath()}>
@@ -284,7 +284,7 @@ export default async function Page({ params }) {
 
   if (!source) notFound()
 
-  const metadata = await source.getNamedExport('metadata').getValue()
+  const metadata = await source.getExport('metadata').getValue()
 
   return (
     <>
@@ -314,9 +314,7 @@ Similar to above, we can get the value of the `metadata` constant for a collecti
 import { Components } from '@/collections'
 
 export default async function Page() {
-  const metadata = await Components.getSource()
-    .getNamedExport('metadata')
-    .getValue()
+  const metadata = await Components.getSource().getExport('metadata').getValue()
 
   return (
     <>
@@ -356,7 +354,7 @@ export function generateStaticParams() {
 
 export async function generateMetadata({ params }) {
   const source = Posts.getSource(params.slug)
-  const frontmatter = await source.getNamedExport('frontmatter').getValue()
+  const frontmatter = await source.getExport('frontmatter').getValue()
 
   return getSiteMetadata({
     title: `${frontmatter.title} - MDXTS`,
@@ -369,8 +367,8 @@ export default async function Page({ params }) {
 
   if (!source) notFound()
 
-  const Content = await source.getDefaultExport().getValue()
-  const frontmatter = await source.getNamedExport('frontmatter').getValue()
+  const frontmatter = await source.getExport('frontmatter').getValue()
+  const Content = await source.getExport('default').getValue()
 
   return (
     <>
@@ -440,7 +438,7 @@ export default async function BlogPage() {
 }
 
 async function BlogPost({ source }: { source: PostSource }) {
-  const frontmatter = await source.getNamedExport('frontmatter').getValue()
+  const frontmatter = await source.getExport('frontmatter').getValue()
 
   return (
     <li>
@@ -476,7 +474,7 @@ export default async function Page({ params }) {
 
   if (!Component && !ComponentMDX) notFound()
 
-  const Content = await ComponentMDX.getDefaultExport().getValue()
+  const Content = await ComponentMDX.getExport('default').getValue()
 
   return (
     <>
@@ -505,7 +503,7 @@ export function generateStaticParams() {
   return ComponentExamples.getSources().map((Component) => {
     const componentPath = Component.getPath()
 
-    return Component.getNamedExports().map(([exportName]) => ({
+    return Component.getExports().map(([exportName]) => ({
       component: componentPath,
       example: exportName,
     }))
@@ -521,7 +519,7 @@ export default async function Page({
 
   if (!ExampleSource) notFound()
 
-  const ExportedSource = ExampleSource.getNamedExport(params.example)
+  const ExportedSource = ExampleSource.getExport(params.example)
 
   if (!ExportedSource) notFound()
 
@@ -582,7 +580,7 @@ export default async function Page({ params }) {
 
   if (!PackageFile && !PackageMDXFile) notFound()
 
-  const PackageDocs = await PackageMDXFile.getDefaultExport().getValue()
+  const PackageDocs = await PackageMDXFile.getExport('default').getValue()
 
   return (
     <>

--- a/apps/site/app/(site)/collections/intro.mdx
+++ b/apps/site/app/(site)/collections/intro.mdx
@@ -63,8 +63,8 @@ export default async function Page({ params }) {
 
   if (!source) notFound()
 
-  const frontmatter = await source.getNamedExport('frontmatter').getValue()
-  const Content = await source.getDefaultExport().getValue()
+  const frontmatter = await source.getExport('frontmatter').getValue()
+  const Content = await source.getExport('default').getValue()
 
   return (
     <>

--- a/apps/site/app/(site)/components/[...slug]/page.tsx
+++ b/apps/site/app/(site)/components/[...slug]/page.tsx
@@ -30,8 +30,8 @@ export default async function Component({
   }
 
   const mdxSource = ComponentsMDXCollection.getSource(componentsPathname)
-  const mdxHeadings = await mdxSource?.getNamedExport('headings').getValue()
-  const Content = await mdxSource?.getDefaultExport().getValue()
+  const mdxHeadings = await mdxSource?.getExport('headings').getValue()
+  const Content = await mdxSource?.getExport('default').getValue()
   const examplesSource = componentSource.getSource('examples')
   const examplesSources = await examplesSource?.getSources()
   const isExamplesPage = params.slug.at(-1) === 'examples'

--- a/apps/site/components/DocumentSource.tsx
+++ b/apps/site/components/DocumentSource.tsx
@@ -11,9 +11,9 @@ export async function DocumentSource<
     headings: Headings
   }>,
 >({ source }: { source: Source }) {
-  const Content = await source.getDefaultExport().getValue()
-  const metadata = await source.getNamedExport('metadata').getValue()
-  const headings = await source.getNamedExport('headings').getValue()
+  const Content = await source.getExport('default').getValue()
+  const metadata = await source.getExport('metadata').getValue()
+  const headings = await source.getExport('headings').getValue()
   const updatedAt = await source.getUpdatedAt()
   const editPath = source.getEditPath()
   const [previousSource, nextSource] = await source.getSiblings({

--- a/apps/site/components/Sidebar/Sidebar.tsx
+++ b/apps/site/components/Sidebar/Sidebar.tsx
@@ -16,7 +16,7 @@ async function TreeNavigation({
   const sources = await source.getSources({ depth: 1 })
   const depth = source.getDepth()
   const path = source.getPath()
-  const metadata = await source.getNamedExport('metadata').getValue()
+  const metadata = await source.getExport('metadata').getValue()
 
   if (sources.length === 0) {
     return (

--- a/examples/blog/app/[slug]/page.tsx
+++ b/examples/blog/app/[slug]/page.tsx
@@ -7,8 +7,8 @@ export async function generateStaticParams() {
 
 export default async function Page({ params }: { params: { slug: string } }) {
   const PostSource = PostsCollection.getSource(params.slug)
-  const Content = await PostSource.getDefaultExport().getValue()
-  const frontmatter = await PostSource.getNamedExport('frontmatter').getValue()
+  const Content = await PostSource.getExport('default').getValue()
+  const frontmatter = await PostSource.getExport('frontmatter').getValue()
   const formattedDate = new Intl.DateTimeFormat('en-US', {
     year: 'numeric',
     month: '2-digit',

--- a/examples/blog/app/page.tsx
+++ b/examples/blog/app/page.tsx
@@ -10,9 +10,7 @@ export default async function Page() {
       <ul>
         {allPosts.map(async (post) => {
           const path = post.getPath()
-          const frontmatter = await post
-            .getNamedExport('frontmatter')
-            .getValue()
+          const frontmatter = await post.getExport('frontmatter').getValue()
 
           return (
             <li key={path}>

--- a/examples/blog/collections.ts
+++ b/examples/blog/collections.ts
@@ -23,8 +23,8 @@ export const PostsCollection = collection<{
         return 0
       }
 
-      const aFrontmatter = await a.getNamedExport('frontmatter').getValue()
-      const bFrontmatter = await b.getNamedExport('frontmatter').getValue()
+      const aFrontmatter = await a.getExport('frontmatter').getValue()
+      const bFrontmatter = await b.getExport('frontmatter').getValue()
 
       return bFrontmatter.date.getTime() - aFrontmatter.date.getTime()
     },

--- a/examples/design-system/app/components/[...slug]/page.tsx
+++ b/examples/design-system/app/components/[...slug]/page.tsx
@@ -43,7 +43,7 @@ export default async function Component({
     ...componentsPathname,
     'readme',
   ])
-  const Readme = await readmeSource?.getDefaultExport().getValue()
+  const Readme = await readmeSource?.getExport('default').getValue()
   const examplesSource = componentSource.getSource('examples')
   const examples = await examplesSource?.getSources()
   const isExamplesPage = params.slug.at(-1) === 'examples'

--- a/packages/renoun/src/utils/get-exported-declaration.ts
+++ b/packages/renoun/src/utils/get-exported-declaration.ts
@@ -1,6 +1,6 @@
-import type { ExportedDeclarations } from "ts-morph";
-import tsMorph from "ts-morph";
-const { Node } = tsMorph;
+import type { ExportedDeclarations } from 'ts-morph'
+import tsMorph from 'ts-morph'
+const { Node } = tsMorph
 
 /** Unwraps exported declarations from a source file. */
 export function getExportedDeclaration(


### PR DESCRIPTION
Removes `getDefaultExport` and `getNamedExport` from collection export sources in favor of a new `getExport` method. This method works exactly the same as the previous `getNamedExport` method with the addition of accepting `default` as an export. This simplifies the API and reduces the number of methods needed to query an export source.

### Breaking Changes

Update any usage of `getDefaultExport` and `getNamedExport` to use the new `getExport` method:

- `getDefaultExport()` -> `getExport('default')`
- `getNamedExport('metadata')` -> `getExport('metadata')`