### PR TITLE
composite collections

### DIFF
--- a/.changeset/famous-hairs-vanish.md
+++ b/.changeset/famous-hairs-vanish.md
@@ -2,7 +2,7 @@
 'renoun': minor
 ---
 
-Introduces a concept of "composite collections". This allows providing a set of collections to the `collection` utility to group collections into one list:
+Introduces a concept of "composite collections". This allows overloading the `collection` utility to treat a set of collections as a single collection:
 
 ```tsx
 const CollectionsCollection = collection({
@@ -16,8 +16,20 @@ const ComponentsCollection = collection({
 })
 
 const AllCollections = collection(CollectionsCollection, ComponentsCollection)
+```
 
+When getting a source from a composite collection, the `<FileSystemSource>.getSiblings` method will account for all collections in the composite collection:
+
+```tsx
 const source = AllCollections.getSource('collections/index')!
-// now aware there are multiple collections to navigate through
+
 const [previousSource, nextSource] = await source.getSiblings()
+```
+
+A new `<Collection>.hasSource` type guard is also available to help constrain the type of the source when working with composite collections:
+
+```tsx
+if (ComponentsCollection.hasSource(nextSource)) {
+  // nextSource is now typed as a ComponentsCollection source
+}
 ```

--- a/.changeset/famous-hairs-vanish.md
+++ b/.changeset/famous-hairs-vanish.md
@@ -1,0 +1,23 @@
+---
+'renoun': minor
+---
+
+Introduces a concept of "composite collections". This allows providing a set of collections to the `collection` utility to group collections into one list:
+
+```tsx
+const CollectionsCollection = collection({
+  filePattern: 'src/collections/index.tsx',
+  baseDirectory: 'collections',
+})
+
+const ComponentsCollection = collection({
+  filePattern: 'src/components/**/*.{ts,tsx}',
+  baseDirectory: 'components',
+})
+
+const AllCollections = collection(CollectionsCollection, ComponentsCollection)
+
+const source = AllCollections.getSource('collections/index')!
+// now aware there are multiple collections to navigate through
+const [previousSource, nextSource] = await source.getSiblings()
+```

--- a/apps/site/app/(site)/collections/page.tsx
+++ b/apps/site/app/(site)/collections/page.tsx
@@ -30,7 +30,7 @@ export default async function Page() {
           <h1 css={{ fontSize: '3rem', margin: 0 }}>Collections</h1>
           <Content />
         </div>
-        {/* <div>
+        <div>
           <h2
             id="api-reference"
             css={{
@@ -45,7 +45,7 @@ export default async function Page() {
           {sourceExports.map((exportSource) => (
             <APIReference key={exportSource.getSlug()} source={exportSource} />
           ))}
-        </div> */}
+        </div>
       </div>
 
       <aside

--- a/apps/site/app/(site)/collections/page.tsx
+++ b/apps/site/app/(site)/collections/page.tsx
@@ -30,7 +30,7 @@ export default async function Page() {
           <h1 css={{ fontSize: '3rem', margin: 0 }}>Collections</h1>
           <Content />
         </div>
-        <div>
+        {/* <div>
           <h2
             id="api-reference"
             css={{
@@ -45,7 +45,7 @@ export default async function Page() {
           {sourceExports.map((exportSource) => (
             <APIReference key={exportSource.getSlug()} source={exportSource} />
           ))}
-        </div>
+        </div> */}
       </div>
 
       <aside

--- a/apps/site/app/(site)/components/[...slug]/page.tsx
+++ b/apps/site/app/(site)/components/[...slug]/page.tsx
@@ -4,7 +4,11 @@ import type { ExportSource } from 'renoun/collections'
 import { notFound } from 'next/navigation'
 import { GeistMono } from 'geist/font/mono'
 
-import { ComponentsCollection, ComponentsMDXCollection } from '@/collections'
+import {
+  AllCollections,
+  ComponentsCollection,
+  ComponentsMDXCollection,
+} from '@/collections'
 import { MDXContent } from '@/components/MDXContent'
 import { SiblingLink } from '@/components/SiblingLink'
 import { TableOfContents } from '@/components/TableOfContents'
@@ -23,9 +27,9 @@ export default async function Component({
   params: { slug: string[] }
 }) {
   const componentsPathname = ['components', ...params.slug]
-  const componentSource = ComponentsCollection.getSource(componentsPathname)
+  const componentSource = AllCollections.getSource(componentsPathname)
 
-  if (!componentSource) {
+  if (!ComponentsCollection.hasSource(componentSource)) {
     notFound()
   }
 
@@ -175,10 +179,24 @@ export default async function Component({
             }}
           >
             {previousSource ? (
-              <SiblingLink source={previousSource} direction="previous" />
+              <SiblingLink
+                source={previousSource}
+                direction="previous"
+                variant={
+                  ComponentsCollection.hasSource(previousSource)
+                    ? 'name'
+                    : 'title'
+                }
+              />
             ) : null}
             {nextSource ? (
-              <SiblingLink source={nextSource} direction="next" />
+              <SiblingLink
+                source={nextSource}
+                direction="next"
+                variant={
+                  ComponentsCollection.hasSource(nextSource) ? 'name' : 'title'
+                }
+              />
             ) : null}
           </nav>
         </div>

--- a/apps/site/app/(site)/docs/[...slug]/page.tsx
+++ b/apps/site/app/(site)/docs/[...slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation'
 
-import { DocsCollection } from '@/collections'
+import { AllCollections, DocsCollection } from '@/collections'
 import { DocumentSource } from '@/components/DocumentSource'
 
 export async function generateStaticParams() {
@@ -12,9 +12,9 @@ export async function generateStaticParams() {
 }
 
 export default async function Doc({ params }: { params: { slug: string[] } }) {
-  const docSource = DocsCollection.getSource(['docs', ...params.slug])
+  const docSource = AllCollections.getSource(['docs', ...params.slug])
 
-  if (!docSource) {
+  if (!DocsCollection.hasSource(docSource)) {
     notFound()
   }
 

--- a/apps/site/app/(site)/guides/[...slug]/page.tsx
+++ b/apps/site/app/(site)/guides/[...slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation'
 
-import { GuidesCollection } from '@/collections'
+import { AllCollections, GuidesCollection } from '@/collections'
 import { DocumentSource } from '@/components/DocumentSource'
 
 export async function generateStaticParams() {
@@ -12,9 +12,9 @@ export async function generateStaticParams() {
 }
 
 export default async function Doc({ params }: { params: { slug: string[] } }) {
-  const docSource = GuidesCollection.getSource(['guides', ...params.slug])
+  const docSource = AllCollections.getSource(['guides', ...params.slug])
 
-  if (!docSource) {
+  if (!GuidesCollection.hasSource(docSource)) {
     notFound()
   }
 

--- a/apps/site/collections.ts
+++ b/apps/site/collections.ts
@@ -132,3 +132,9 @@ export const ComponentsMDXCollection = collection<{
   },
   (slug) => import(`../../packages/renoun/src/components/${slug}.mdx`)
 )
+
+export const AllCollections = collection(
+  DocsCollection,
+  GuidesCollection,
+  ComponentsCollection
+)

--- a/packages/renoun/src/collections/docs/index.mdx
+++ b/packages/renoun/src/collections/docs/index.mdx
@@ -106,7 +106,7 @@ const AllCollections = collection(PostsCollection, ComponentsCollection)
 
 With this setup, `AllCollections` allows you to query across both `PostsCollection` and `ComponentsCollection` seamlessly.
 
-### Querying a Composite Collection
+### Querying Across Collections
 
 When retrieving a source and querying for siblings, composite collections will account for all sources across the collections it comprises:
 
@@ -120,7 +120,7 @@ const [previousSource, nextSource] = await source.getSiblings()
 
 Here, `source.getSiblings()` will return the sources from both `PostsCollection` and `ComponentsCollection` as a combined set.
 
-### Type Guarding with Composite Collections
+### Narrowing Source Types
 
 Collections provide a type guard to check if a source belongs to a specific collection within a composite collection. You can use the `<Collection>.hasSource` method to safely narrow the type of a source when working with composite collections:
 

--- a/packages/renoun/src/collections/docs/index.mdx
+++ b/packages/renoun/src/collections/docs/index.mdx
@@ -80,6 +80,60 @@ export default async function Page({ params }: { params: { slug: string } }) {
 }
 ```
 
-Collections can be used to generate static pages, create navigations, and much more. At their core, they abstract files and directories into either a `CollectionSource`, `FileSystemSource`, or `ExportSource` allowing you to analyze and render them programmatically.
+## Composite Collections
 
-Learn more at the [recipes](/collections/recipes) page.
+In addition to creating individual collections, Renoun also allows you to define **composite collections**. A composite collection is a combination of multiple collections, allowing you to treat them as a single entity. This can be useful when you want to query across different directories or file patterns while maintaining a unified interface.
+
+### Creating a Composite Collection
+
+Let's say you have two collections, one for blog posts, and another for components. Using a composite collection, you can combine these into a single collection that can be queried as if it were one:
+
+```tsx
+import { collection } from 'renoun/collections'
+
+const PostsCollection = collection({
+  filePattern: 'posts/*.mdx',
+  baseDirectory: 'posts',
+})
+
+const ComponentsCollection = collection({
+  filePattern: 'src/components/**/*.{ts,tsx}',
+  baseDirectory: 'components',
+})
+
+const AllCollections = collection(PostsCollection, ComponentsCollection)
+```
+
+With this setup, `AllCollections` allows you to query across both `PostsCollection` and `ComponentsCollection` seamlessly.
+
+### Querying a Composite Collection
+
+When retrieving a source and querying for siblings, composite collections will account for all sources across the collections it comprises:
+
+```tsx allowErrors
+const source = AllCollections.getSource(
+  'posts/how-to-build-a-button-component'
+)!
+
+const [previousSource, nextSource] = await source.getSiblings()
+```
+
+Here, `source.getSiblings()` will return the sources from both `PostsCollection` and `ComponentsCollection` as a combined set.
+
+### Type Guarding with Composite Collections
+
+Collections provide a type guard to check if a source belongs to a specific collection within a composite collection. You can use the `<Collection>.hasSource` method to safely narrow the type of a source when working with composite collections:
+
+```tsx allowErrors
+if (ComponentsCollection.hasSource(nextSource)) {
+  // nextSource is now typed as a ComponentsCollection source
+}
+```
+
+This type guard ensures that you’re working with the correct source type within a composite collection, allowing you to access schema-specific exports.
+
+## Conclusion
+
+Collections can be used to generate static pages, create navigations, site maps and much more. At their core, they abstract files and directories into either a `CollectionSource`, `FileSystemSource`, or `ExportSource` allowing you to analyze and render them programmatically.
+
+Explore more ways to utilize collections by visiting the [recipes](/collections/recipes) page for practical examples.

--- a/packages/renoun/src/collections/get-collection-call-expressions.ts
+++ b/packages/renoun/src/collections/get-collection-call-expressions.ts
@@ -13,9 +13,12 @@ export function getCollectionCallExpressions(project: Project) {
     .findReferencesAsNodes()
     .forEach((node) => {
       const callExpression = node.getParentOrThrow()
-
       if (tsMorph.Node.isCallExpression(callExpression)) {
-        allCollections.push(callExpression)
+        const [firstArgument] = callExpression.getArguments()
+
+        if (tsMorph.Node.isObjectLiteralExpression(firstArgument)) {
+          allCollections.push(callExpression)
+        }
       }
     })
 

--- a/packages/renoun/src/collections/index.test.ts
+++ b/packages/renoun/src/collections/index.test.ts
@@ -1,0 +1,27 @@
+import type { ComponentType } from 'react'
+import { describe, it, expect } from 'vitest'
+
+import { collection } from './index'
+
+describe('collections', () => {
+  it('merges composite collection siblings', async () => {
+    const CollectionsCollection = collection({
+      filePattern: 'src/collections/index.tsx',
+      baseDirectory: 'collections',
+    })
+    const ComponentsCollection = collection<{
+      [key: string]: ComponentType
+    }>({
+      filePattern: 'src/components/**/*.{ts,tsx}',
+      baseDirectory: 'components',
+    })
+    const AllCollections = collection(
+      CollectionsCollection,
+      ComponentsCollection
+    )
+    const source = AllCollections.getSource('collections/index')!
+    const [, nextSource] = await source.getSiblings()
+
+    expect(nextSource).toBeDefined()
+  })
+})

--- a/packages/renoun/src/collections/index.tsx
+++ b/packages/renoun/src/collections/index.tsx
@@ -178,7 +178,11 @@ export type CollectionSource<Exports extends FileExports> = Omit<
   BaseSource,
   'getEditPath' | 'getPathSegments'
 > &
-  SourceProvider<Exports>
+  SourceProvider<Exports> & {
+    hasSource(
+      source: FileSystemSource<any> | undefined
+    ): source is FileSystemSource<Exports>
+  }
 
 export interface CollectionOptions<Exports extends FileExports> {
   /** The file pattern used to match source files. */
@@ -1120,6 +1124,12 @@ You can fix this error by ensuring the following:
         // remove file extension: Button.tsx -> Button
         .replace(/\.[^/.]+$/, '')
     )
+  }
+
+  hasSource(
+    source: FileSystemSource<any> | undefined
+  ): source is FileSystemSource<AllExports> {
+    return source ? this.#sources.has(source.getPath()) : false
   }
 }
 

--- a/packages/renoun/src/collections/index.tsx
+++ b/packages/renoun/src/collections/index.tsx
@@ -36,8 +36,8 @@ export type FilePatterns<Extension extends string = string> =
   | `${string}${Extension}`
   | `${string}${Extension}${string}`
 
-export interface FileExports {
-  [key: string]: any
+export type FileExports = {
+  [key: string]: unknown
 }
 
 export interface BaseSource {
@@ -66,8 +66,7 @@ type PositiveIntegerOrInfinity<Type extends number> = `${Type}` extends
   ? never
   : Type
 
-export interface BaseSourceWithGetters<Exports extends FileExports>
-  extends BaseSource {
+export interface SourceProvider<Exports extends FileExports> {
   /** Retrieves a source in the immediate directory or sub-directory by its path. */
   getSource(path?: string | string[]): FileSystemSource<Exports> | undefined
 
@@ -124,7 +123,8 @@ export interface ExportSource<Value> extends BaseSource {
 }
 
 export interface FileSystemSource<Exports extends FileExports>
-  extends BaseSourceWithGetters<Exports> {
+  extends BaseSource,
+    SourceProvider<Exports> {
   /** The base file name or directory name. */
   getName(): string
 
@@ -167,12 +167,18 @@ export interface FileSystemSource<Exports extends FileExports>
 
   /** If the source is a directory. */
   isDirectory(): boolean
+
+  /** If the source is from a specific collection. Useful for composite collections. */
+  isFromCollection<Exports extends FileExports>(
+    collection: Collection<Exports>
+  ): this is FileSystemSource<Exports>
 }
 
 export type CollectionSource<Exports extends FileExports> = Omit<
-  BaseSourceWithGetters<Exports>,
+  BaseSource,
   'getEditPath' | 'getPathSegments'
->
+> &
+  SourceProvider<Exports>
 
 export interface CollectionOptions<Exports extends FileExports> {
   /** The file pattern used to match source files. */
@@ -466,6 +472,7 @@ class Source<AllExports extends FileExports>
 
   constructor(
     private collection: Collection<AllExports>,
+    private compositeCollection: CompositeCollection<any> | undefined,
     private sourceFileOrDirectory: SourceFile | Directory
   ) {
     this.#sourcePath = getFileSystemSourcePath(this.sourceFileOrDirectory)
@@ -477,6 +484,12 @@ class Source<AllExports extends FileExports>
 
   isDirectory() {
     return this.sourceFileOrDirectory instanceof tsMorph.Directory
+  }
+
+  isFromCollection<Exports extends FileExports>(
+    collection: Collection<Exports>
+  ): this is FileSystemSource<Exports> {
+    return (this.collection as unknown as Collection<Exports>) === collection
   }
 
   getCollection() {
@@ -633,20 +646,9 @@ class Source<AllExports extends FileExports>
       )
     }
 
-    const minDepth = this.collection.getDepth()
-    const maxDepth = depth === Infinity ? Infinity : this.getDepth() + depth
-    const seenPaths = new Set<string>()
-    const filteredSources = (
-      await this.collection.getFileSystemSources()
-    ).filter((source) => {
-      const sourcePath = source.getPath()
-      if (seenPaths.has(sourcePath)) {
-        return false
-      }
-      seenPaths.add(sourcePath)
-
-      const sourceDepth = source.getDepth()
-      return sourceDepth >= minDepth && sourceDepth <= maxDepth
+    const collection = this.compositeCollection || this.collection
+    const filteredSources = await collection.getSources({
+      depth: depth === Infinity ? Infinity : this.getDepth() + depth,
     })
     const currentIndex = filteredSources.findIndex(
       (source) => source.getPath() === this.getPath()
@@ -659,7 +661,10 @@ class Source<AllExports extends FileExports>
     const previousSource = filteredSources[currentIndex - 1]
     const nextSource = filteredSources[currentIndex + 1]
 
-    return [previousSource, nextSource]
+    return [previousSource, nextSource] as [
+      previous?: FileSystemSource<AllExports> | undefined,
+      next?: FileSystemSource<AllExports> | undefined,
+    ]
   }
 
   getExport<Name extends keyof AllExports>(name: Name) {
@@ -807,6 +812,7 @@ You can fix this error by taking one of the following actions:
   }
 }
 
+/** Creates a collection of file system sources based on a file pattern. */
 class Collection<AllExports extends FileExports>
   implements CollectionSource<AllExports>
 {
@@ -903,14 +909,21 @@ You can fix this error by ensuring the following:
     })
   }
 
-  getFileSystemSource(sourceFileOrDirectory: SourceFile | Directory) {
+  getFileSystemSource(
+    sourceFileOrDirectory: SourceFile | Directory,
+    compositeCollection?: CompositeCollection<any>
+  ) {
     const path = this.sourcePathMap.get(
       getFileSystemSourcePath(sourceFileOrDirectory)
     )!
-    return this.getSource(path)
+    return this.getSource(
+      path,
+      // @ts-expect-error - private property
+      compositeCollection
+    )
   }
 
-  async getFileSystemSources() {
+  async getFileSystemSources(compositeCollection?: CompositeCollection<any>) {
     const tsConfig = this.project.getCompilerOptions()
     const tsConfigDirectory = dirname(tsConfig.configFilePath as string)
     let exclude: string[] = []
@@ -935,7 +948,7 @@ You can fix this error by ensuring the following:
           }
         }
 
-        return this.getFileSystemSource(fileSystemSource)
+        return this.getFileSystemSource(fileSystemSource, compositeCollection)
       })
       .filter((source) => {
         if (source) {
@@ -1026,6 +1039,7 @@ You can fix this error by ensuring the following:
   getSource(
     path: string | string[] = 'index'
   ): FileSystemSource<AllExports> | undefined {
+    const compositeCollection = arguments[1] as CompositeCollection<any>
     let pathString = Array.isArray(path) ? path.join('/') : path
 
     if (this.#sources.has(pathString)) {
@@ -1062,7 +1076,7 @@ You can fix this error by ensuring the following:
       return undefined
     }
 
-    const source = new Source(this, sourceFileOrDirectory)
+    const source = new Source(this, compositeCollection, sourceFileOrDirectory)
 
     this.#sources.set(pathString, source)
 
@@ -1076,9 +1090,10 @@ You can fix this error by ensuring the following:
       )
     }
 
+    const compositeCollection = arguments[1] as CompositeCollection<any>
+    const sources = await this.getFileSystemSources(compositeCollection)
     const minDepth = this.getDepth()
     const maxDepth = depth === Infinity ? Infinity : minDepth + depth
-    const sources = await this.getFileSystemSources()
     const seenPaths = new Set<string>()
 
     return sources.filter((source) => {
@@ -1108,21 +1123,100 @@ You can fix this error by ensuring the following:
   }
 }
 
+type FileSystemSourceFromCollection<Collection> =
+  Collection extends CollectionSource<infer Exports>
+    ? FileSystemSource<Exports>
+    : never
+
+type FileSystemSourceUnion<Collections extends CollectionSource<any>[]> = {
+  [Key in keyof Collections]: FileSystemSourceFromCollection<Collections[Key]>
+}[number]
+
 /**
- * Creates a collection of sources based on a specified file pattern.
+ * Combines multiple collections into a single source provider that can be queried together.
+ * This is useful for creating feeds or navigations that span multiple collections.
+ */
+class CompositeCollection<Collections extends CollectionSource<any>[]>
+  implements SourceProvider<any>
+{
+  private collections: Collections
+
+  constructor(...collections: Collections) {
+    this.collections = collections
+  }
+
+  getSource(
+    path?: string | string[]
+  ): FileSystemSourceUnion<Collections> | undefined {
+    for (const collection of this.collections) {
+      const source = collection.getSource(
+        path,
+        // @ts-expect-error - private property
+        this
+      )
+      if (source) {
+        return source as FileSystemSourceUnion<Collections>
+      }
+    }
+    return undefined
+  }
+
+  async getSources({ depth = Infinity }: { depth?: number } = {}): Promise<
+    FileSystemSourceUnion<Collections>[]
+  > {
+    const sourcesArrays = await Promise.all(
+      this.collections.map((collection) =>
+        collection.getSources(
+          { depth },
+          // @ts-expect-error - private property
+          this
+        )
+      )
+    )
+    return sourcesArrays.flat() as FileSystemSourceUnion<Collections>[]
+  }
+}
+
+/**
+ * Creates a collection of file system sources based on a file pattern.
  * Note, a dynamic import getter will automatically be generated for each file extension at the call site of this collection.
  *
- * @param filePattern - A pattern to match a set of source files (e.g., "*.ts", "*.mdx").
- * @param options - Optional settings for the collection, including base directory, base path, TypeScript config file path, and a custom sort function.
- * @returns A collection object that provides methods to retrieve individual sources or all sources matching the pattern.
+ * @param options - Settings for the collection, including base directory, base path, TypeScript config file path, and a custom sort function.
+ * @param getImport - A dynamic import getter function that returns the module exports for a given slug. This is automatically generated based on the `filePattern` extensions.
+ * @returns A collection object that provides methods to retrieve all sources or an individual source that match the file pattern.
  */
-export function collection<
-  AllExports extends { [key: string]: any } = { [key: string]: any },
->(
+export function collection<AllExports extends FileExports = FileExports>(
   options: CollectionOptions<AllExports>,
   getImport?: GetImport | GetImport[]
-): CollectionSource<AllExports> {
-  return new Collection<AllExports>(options, getImport)
+): CollectionSource<AllExports>
+
+/**
+ * Creates a composite collection of file system sources based on multiple collections.
+ * This is useful for creating feeds or navigations that span multiple collections.
+ *
+ * @param collections - A list of collections to combine.
+ * @returns A composite collection that provides methods to retrieve all sources or an individual source.
+ */
+export function collection<Collections extends CollectionSource<any>[]>(
+  ...collections: Collections
+): CompositeCollection<Collections>
+
+export function collection<AllExports extends FileExports = FileExports>(
+  ...args:
+    | [CollectionOptions<AllExports>, (GetImport | GetImport[])?]
+    | CollectionSource<AllExports>[]
+):
+  | CollectionSource<AllExports>
+  | CompositeCollection<CollectionSource<AllExports>[]> {
+  if (args[0] instanceof Collection) {
+    return new CompositeCollection(...(args as CollectionSource<AllExports>[]))
+  } else {
+    const [options, getImport] = args as [
+      CollectionOptions<AllExports>,
+      GetImport?,
+    ]
+    return new Collection<AllExports>(options, getImport)
+  }
 }
 
 /** Get all sources for a file pattern. */

--- a/packages/renoun/src/utils/get-exported-declaration.test.ts
+++ b/packages/renoun/src/utils/get-exported-declaration.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { Project } from 'ts-morph'
+
+import { getExportedDeclaration } from './get-exported-declaration'
+
+describe('getExportedDeclaration', () => {
+  const project = new Project()
+
+  it('should return the only exported declaration when one is present', () => {
+    const sourceFile = project.createSourceFile(
+      'singleExport.ts',
+      `
+      export function singleFunction() {
+        return true;
+      }
+    `
+    )
+
+    const exportedDeclarations = sourceFile.getExportedDeclarations()
+    const result = getExportedDeclaration(
+      exportedDeclarations,
+      'singleFunction'
+    )
+
+    expect(result).toBeDefined()
+  })
+
+  it('should return the implementation when overloads are present', () => {
+    const sourceFile = project.createSourceFile(
+      'overloads.ts',
+      `
+      export function functionOverload(param: string): void;
+      export function functionOverload(param: number): void;
+      export function functionOverload(param: string | number) {}
+    `
+    )
+
+    const exportedDeclarations = sourceFile.getExportedDeclarations()
+    const result = getExportedDeclaration(
+      exportedDeclarations,
+      'functionOverload'
+    )
+
+    expect(result).toBeDefined()
+  })
+})

--- a/packages/renoun/src/utils/get-exported-declaration.ts
+++ b/packages/renoun/src/utils/get-exported-declaration.ts
@@ -14,6 +14,15 @@ export function getExportedDeclaration(
     return undefined
   }
 
+  // Check if there are overloads and return the implementation if found
+  const implementationDeclaration = exportDeclarations.find((declaration) => {
+    return Node.isFunctionDeclaration(declaration) && declaration.hasBody()
+  })
+
+  if (implementationDeclaration) {
+    return implementationDeclaration
+  }
+
   // Filter out types if multiple declarations are found
   if (exportDeclarations.length > 1) {
     const filteredExportDeclarations = exportDeclarations.filter(
@@ -23,18 +32,16 @@ export function getExportedDeclaration(
         !Node.isPropertyAccessExpression(declaration.getParentOrThrow())
     )
 
-    // if (filteredExportDeclarations.length > 1) {
-    //   const filePath = exportDeclarations[0]
-    //     .getSourceFile()
-    //     .getFilePath()
-    //     .replace(process.cwd(), '')
+    if (filteredExportDeclarations.length > 1) {
+      const filePath = exportDeclarations[0]
+        .getSourceFile()
+        .getFilePath()
+        .replace(process.cwd(), '')
 
-    //   throw new Error(
-    //     `[renoun] Multiple declarations found for export after filtering type aliases, interfaces, and property access expressions in source file at ${filePath}. Only one export declaration is currently allowed. Please file an issue for support.`
-    //   )
-    // }
-
-    return filteredExportDeclarations[0]
+      throw new Error(
+        `[renoun] Multiple declarations found for export after filtering type aliases, interfaces, and property access expressions in source file at ${filePath}. Only one export declaration is currently allowed. Please file an issue for support.`
+      )
+    }
   }
 
   return exportDeclarations[0]

--- a/packages/renoun/src/utils/get-exported-declaration.ts
+++ b/packages/renoun/src/utils/get-exported-declaration.ts
@@ -23,16 +23,16 @@ export function getExportedDeclaration(
         !Node.isPropertyAccessExpression(declaration.getParentOrThrow())
     )
 
-    if (filteredExportDeclarations.length > 1) {
-      const filePath = exportDeclarations[0]
-        .getSourceFile()
-        .getFilePath()
-        .replace(process.cwd(), '')
+    // if (filteredExportDeclarations.length > 1) {
+    //   const filePath = exportDeclarations[0]
+    //     .getSourceFile()
+    //     .getFilePath()
+    //     .replace(process.cwd(), '')
 
-      throw new Error(
-        `[renoun] Multiple declarations found for export after filtering type aliases, interfaces, and property access expressions in source file at ${filePath}. Only one export declaration is currently allowed. Please file an issue for support.`
-      )
-    }
+    //   throw new Error(
+    //     `[renoun] Multiple declarations found for export after filtering type aliases, interfaces, and property access expressions in source file at ${filePath}. Only one export declaration is currently allowed. Please file an issue for support.`
+    //   )
+    // }
 
     return filteredExportDeclarations[0]
   }


### PR DESCRIPTION
Introduces a concept of "composite collections". This allows overloading the `collection` utility to treat a set of collections as a single collection:

```tsx
const CollectionsCollection = collection({
  filePattern: 'src/collections/index.tsx',
  baseDirectory: 'collections',
})

const ComponentsCollection = collection({
  filePattern: 'src/components/**/*.{ts,tsx}',
  baseDirectory: 'components',
})

const AllCollections = collection(CollectionsCollection, ComponentsCollection)
```

When getting a source from a composite collection, the `<FileSystemSource>.getSiblings` method will account for all collections in the composite collection:

```tsx
const source = AllCollections.getSource('collections/index')!

const [previousSource, nextSource] = await source.getSiblings()
```

A new `<Collection>.hasSource` type guard is also available to help constrain the type of the source when working with composite collections:

```tsx
if (ComponentsCollection.hasSource(nextSource)) {
  // nextSource is now typed as a ComponentsCollection source
}
```
