### PR TITLE
fix infinite type recursion

### DIFF
--- a/.changeset/happy-toes-wash.md
+++ b/.changeset/happy-toes-wash.md
@@ -2,4 +2,15 @@
 'renoun': patch
 ---
 
-Fixes type resolution getting caught in an infinite loop resulting in a maximum call stack exceeded error.
+This update resolves several issues with API references, particularly recursion bugs in the internal `resolveType` utility. The key changes involve an updated algorithm for computing component types, which affects the following case:
+
+- Named functions with a capitalized first letter and a single non-object argument are now interpreted as components when they should be functions. This is an unintended behavior change and will be corrected in an upcoming update.
+
+### Type References
+
+Type references are now split into two maps that serve the following use cases:
+
+- **Prevent Infinite Recursion**: A map of type references is maintained during type iteration of the root type to prevent infinite recursion.
+- **Optimized Type Handling for Exported Declarations**:
+  - Adds an explicit map for tracking exported declarations to avoid type duplication.
+  - Improves performance and establishes a link between types.

--- a/.changeset/happy-toes-wash.md
+++ b/.changeset/happy-toes-wash.md
@@ -1,0 +1,5 @@
+---
+'renoun': patch
+---
+
+Fixes type resolution getting caught in an infinite loop resulting in a maximum call stack exceeded error.

--- a/packages/renoun/src/utils/resolve-type.test.ts
+++ b/packages/renoun/src/utils/resolve-type.test.ts
@@ -5272,7 +5272,7 @@ describe('processProperties', () => {
                 },
                 {
                   "filePath": "test.ts",
-                  "kind": "Intersection",
+                  "kind": "Object",
                   "name": undefined,
                   "position": {
                     "end": {
@@ -5286,19 +5286,25 @@ describe('processProperties', () => {
                   },
                   "properties": [
                     {
+                      "context": "property",
+                      "defaultValue": undefined,
                       "filePath": "test.ts",
-                      "kind": "Reference",
+                      "isOptional": false,
+                      "isReadonly": false,
+                      "kind": "String",
+                      "name": "color",
                       "position": {
                         "end": {
-                          "column": 36,
+                          "column": 33,
                           "line": 1,
                         },
                         "start": {
-                          "column": 1,
+                          "column": 20,
                           "line": 1,
                         },
                       },
-                      "text": "BaseProps",
+                      "text": "string",
+                      "value": undefined,
                     },
                     {
                       "context": "property",
@@ -7759,7 +7765,7 @@ describe('processProperties', () => {
                 },
                 {
                   "filePath": "test.ts",
-                  "kind": "Intersection",
+                  "kind": "Object",
                   "name": undefined,
                   "position": {
                     "end": {
@@ -7815,19 +7821,116 @@ describe('processProperties', () => {
                       "value": undefined,
                     },
                     {
+                      "context": "property",
+                      "defaultValue": undefined,
+                      "description": "Controls how types are rendered.",
                       "filePath": "test.ts",
-                      "kind": "Reference",
+                      "isOptional": true,
+                      "isReadonly": false,
+                      "kind": "Function",
+                      "name": "children",
                       "position": {
                         "end": {
-                          "column": 2,
-                          "line": 20,
+                          "column": 23,
+                          "line": 19,
                         },
                         "start": {
-                          "column": 1,
-                          "line": 15,
+                          "column": 3,
+                          "line": 17,
                         },
                       },
-                      "text": "BaseExportedTypesProps",
+                      "signatures": [
+                        {
+                          "kind": "FunctionSignature",
+                          "modifier": undefined,
+                          "parameters": [
+                            {
+                              "context": "parameter",
+                              "defaultValue": undefined,
+                              "description": undefined,
+                              "element": {
+                                "filePath": "test.ts",
+                                "kind": "Object",
+                                "name": undefined,
+                                "position": {
+                                  "end": {
+                                    "column": 6,
+                                    "line": 11,
+                                  },
+                                  "start": {
+                                    "column": 5,
+                                    "line": 5,
+                                  },
+                                },
+                                "properties": [
+                                  {
+                                    "context": "property",
+                                    "defaultValue": undefined,
+                                    "filePath": "test.ts",
+                                    "isOptional": false,
+                                    "isReadonly": false,
+                                    "kind": "String",
+                                    "name": "name",
+                                    "position": {
+                                      "end": {
+                                        "column": 21,
+                                        "line": 7,
+                                      },
+                                      "start": {
+                                        "column": 7,
+                                        "line": 7,
+                                      },
+                                    },
+                                    "text": "string",
+                                    "value": undefined,
+                                  },
+                                  {
+                                    "context": "property",
+                                    "defaultValue": undefined,
+                                    "filePath": "test.ts",
+                                    "isOptional": false,
+                                    "isReadonly": false,
+                                    "kind": "String",
+                                    "name": "description",
+                                    "position": {
+                                      "end": {
+                                        "column": 40,
+                                        "line": 10,
+                                      },
+                                      "start": {
+                                        "column": 7,
+                                        "line": 10,
+                                      },
+                                    },
+                                    "text": "string",
+                                    "value": undefined,
+                                  },
+                                ],
+                                "text": "{ name: string; description: string; }",
+                              },
+                              "filePath": "test.ts",
+                              "isOptional": false,
+                              "kind": "Array",
+                              "name": "exportedTypes",
+                              "position": {
+                                "end": {
+                                  "column": 55,
+                                  "line": 18,
+                                },
+                                "start": {
+                                  "column": 5,
+                                  "line": 18,
+                                },
+                              },
+                              "text": "Array<{ name: string; description: string; }>",
+                            },
+                          ],
+                          "returnType": "ReactNode",
+                          "text": "(exportedTypes: Array<{ name: string; description: string; }>) => ReactNode",
+                        },
+                      ],
+                      "tags": undefined,
+                      "text": "(exportedTypes: ReturnType<typeof getExportedTypes>) => React.ReactNode",
                     },
                   ],
                   "text": "{ filename: string; value: string; } & BaseExportedTypesProps",

--- a/packages/renoun/src/utils/resolve-type.test.ts
+++ b/packages/renoun/src/utils/resolve-type.test.ts
@@ -1901,7 +1901,143 @@ describe('processProperties', () => {
     const typeAlias = sourceFile.getTypeAliasOrThrow('FileSystemSource')
     const processedProperties = resolveType(typeAlias.getType(), typeAlias)
 
-    // console.log(JSON.stringify(processedProperties, null, 2))
+    expect(processedProperties).toMatchInlineSnapshot(`
+      {
+        "filePath": "test.ts",
+        "kind": "Object",
+        "name": "FileSystemSource",
+        "position": {
+          "end": {
+            "column": 2,
+            "line": 3,
+          },
+          "start": {
+            "column": 1,
+            "line": 1,
+          },
+        },
+        "properties": [
+          {
+            "context": "property",
+            "defaultValue": undefined,
+            "filePath": "test.ts",
+            "isOptional": true,
+            "isReadonly": false,
+            "kind": "Class",
+            "name": "collection",
+            "position": {
+              "end": {
+                "column": 35,
+                "line": 2,
+              },
+              "start": {
+                "column": 3,
+                "line": 2,
+              },
+            },
+            "properties": [
+              {
+                "defaultValue": "undefined",
+                "element": {
+                  "filePath": "test.ts",
+                  "kind": "Object",
+                  "name": "FileSystemSource",
+                  "position": {
+                    "end": {
+                      "column": 2,
+                      "line": 3,
+                    },
+                    "start": {
+                      "column": 1,
+                      "line": 1,
+                    },
+                  },
+                  "properties": [
+                    {
+                      "context": "property",
+                      "defaultValue": undefined,
+                      "filePath": "test.ts",
+                      "isOptional": true,
+                      "isReadonly": false,
+                      "kind": "Class",
+                      "name": "collection",
+                      "position": {
+                        "end": {
+                          "column": 35,
+                          "line": 2,
+                        },
+                        "start": {
+                          "column": 3,
+                          "line": 2,
+                        },
+                      },
+                      "properties": [
+                        {
+                          "defaultValue": "undefined",
+                          "element": {
+                            "filePath": "test.ts",
+                            "kind": "Reference",
+                            "position": {
+                              "end": {
+                                "column": 2,
+                                "line": 3,
+                              },
+                              "start": {
+                                "column": 1,
+                                "line": 1,
+                              },
+                            },
+                            "text": "FileSystemSource<Exports>",
+                          },
+                          "filePath": "test.ts",
+                          "isReadonly": false,
+                          "kind": "Array",
+                          "name": "sources",
+                          "position": {
+                            "end": {
+                              "column": 52,
+                              "line": 6,
+                            },
+                            "start": {
+                              "column": 3,
+                              "line": 6,
+                            },
+                          },
+                          "scope": undefined,
+                          "text": "Array<FileSystemSource<Exports>>",
+                          "visibility": undefined,
+                        },
+                      ],
+                      "text": "Collection<Exports>",
+                    },
+                  ],
+                  "text": "FileSystemSource<Exports>",
+                },
+                "filePath": "test.ts",
+                "isReadonly": false,
+                "kind": "Array",
+                "name": "sources",
+                "position": {
+                  "end": {
+                    "column": 52,
+                    "line": 6,
+                  },
+                  "start": {
+                    "column": 3,
+                    "line": 6,
+                  },
+                },
+                "scope": undefined,
+                "text": "Array<FileSystemSource<Exports>>",
+                "visibility": undefined,
+              },
+            ],
+            "text": "Collection<Exports>",
+          },
+        ],
+        "text": "FileSystemSource<Exports>",
+      }
+    `)
   })
 
   test('references property signature types located in node_modules', () => {

--- a/packages/renoun/src/utils/resolve-type.ts
+++ b/packages/renoun/src/utils/resolve-type.ts
@@ -303,17 +303,12 @@ export function resolveType(
     )
   }
 
-  const isPromise = typeText.startsWith('Promise<') && typeText.endsWith('>')
-
   /* When the type is a property signature, check if it is referencing an exported symbol. */
   if (
     tsMorph.Node.isPropertySignature(enclosingNode) &&
     tsMorph.Node.isExportable(symbolDeclaration) &&
     symbolDeclaration.isExported()
   ) {
-    if (isPromise) {
-      console.log('isReference:', typeText)
-    }
     return {
       kind: 'Reference',
       text: typeText,
@@ -380,9 +375,6 @@ export function resolveType(
             throw new Error(
               `[resolveType]: No file path found for "${typeText}". Please file an issue if you encounter this error.`
             )
-          }
-          if (isPromise) {
-            console.log('isReference:', typeText)
           }
           return {
             kind: 'Reference',

--- a/packages/renoun/src/utils/resolve-type.ts
+++ b/packages/renoun/src/utils/resolve-type.ts
@@ -413,7 +413,7 @@ export function resolveType(
     const hasReference = typeReferences.has(type)
 
     if (
-      (hasReference && !symbolMetadata.isGlobal) ||
+      hasReference ||
       ((isLocallyExportedReference ||
         isExternalNonNodeModuleReference ||
         isNodeModuleReference) &&
@@ -435,8 +435,8 @@ export function resolveType(
     }
   }
 
-  /* If the type is not virtual, store it as a reference. */
-  if (!symbolMetadata.isVirtual) {
+  /* If the type is not global or virtual, store it as a reference. */
+  if (!symbolMetadata.isGlobal && !symbolMetadata.isVirtual) {
     typeReferences.add(type)
   }
 


### PR DESCRIPTION
This update resolves several issues with API references, particularly recursion bugs in the internal `resolveType` utility. The key changes involve an updated algorithm for computing component types, which affects the following case:

- Named functions with a capitalized first letter and a single non-object argument are now interpreted as components when they should be functions. This is an unintended behavior change and will be corrected in an upcoming update.

### Type References

Type references are now split into two maps that serve the following use cases:

- **Prevent Infinite Recursion**: A map of type references is maintained during type iteration of the root type to prevent infinite recursion.
- **Optimized Type Handling for Exported Declarations**:
  - Adds an explicit map for tracking exported declarations to avoid type duplication.
  - Improves performance and establishes a link between types.
