### PR TITLE
simplify collection base directory

### DIFF
--- a/.changeset/smart-beds-learn.md
+++ b/.changeset/smart-beds-learn.md
@@ -1,0 +1,20 @@
+---
+'renoun': major
+---
+
+Simplifies how `baseDirectory` works for `Collection`. This was from a legacy implementation that was not well thought out and caused confusion. This change makes it more explicit and easier to understand.
+
+### Breaking Changes
+
+The `baseDirectory` option for `Collection` is now required to be separate from `filePattern`:
+
+```diff
+import { Collection } from 'renoun/collections'
+
+const components = new Collection({
+--  filePattern: 'src/components/**/*.ts',
+++  filePattern: '**/*.ts',
+--  baseDirectory: 'components',
+++  baseDirectory: 'src/components',
+})
+```

--- a/apps/site/app/(site)/collections/[...slug]/page.tsx
+++ b/apps/site/app/(site)/collections/[...slug]/page.tsx
@@ -5,10 +5,7 @@ import { DocumentSource } from '@/components/DocumentSource'
 
 export async function generateStaticParams() {
   const sources = await CollectionsDocsCollection.getSources()
-
-  return sources
-    .filter((source) => source.isFile())
-    .map((source) => ({ slug: source.getPathSegments() }))
+  return sources.map((source) => ({ slug: source.getPathSegments() }))
 }
 
 export default async function Document({

--- a/apps/site/app/(site)/components/[...slug]/page.tsx
+++ b/apps/site/app/(site)/components/[...slug]/page.tsx
@@ -15,10 +15,7 @@ import { TableOfContents } from '@/components/TableOfContents'
 
 export async function generateStaticParams() {
   const sources = await ComponentsCollection.getSources()
-
-  return sources
-    .filter((source) => source.isFile())
-    .map((source) => ({ slug: source.getPathSegments() }))
+  return sources.map((source) => ({ slug: source.getPathSegments() }))
 }
 
 export default async function Component({

--- a/apps/site/app/(site)/docs/[...slug]/page.tsx
+++ b/apps/site/app/(site)/docs/[...slug]/page.tsx
@@ -5,10 +5,7 @@ import { DocumentSource } from '@/components/DocumentSource'
 
 export async function generateStaticParams() {
   const sources = await DocsCollection.getSources()
-
-  return sources
-    .filter((source) => source.isFile())
-    .map((source) => ({ slug: source.getPathSegments() }))
+  return sources.map((source) => ({ slug: source.getPathSegments() }))
 }
 
 export default async function Doc({ params }: { params: { slug: string[] } }) {

--- a/apps/site/app/(site)/guides/[...slug]/page.tsx
+++ b/apps/site/app/(site)/guides/[...slug]/page.tsx
@@ -5,10 +5,7 @@ import { DocumentSource } from '@/components/DocumentSource'
 
 export async function generateStaticParams() {
   const sources = await GuidesCollection.getSources()
-
-  return sources
-    .filter((source) => source.isFile())
-    .map((source) => ({ slug: source.getPathSegments() }))
+  return sources.map((source) => ({ slug: source.getPathSegments() }))
 }
 
 export default async function Doc({ params }: { params: { slug: string[] } }) {

--- a/apps/site/collections.ts
+++ b/apps/site/collections.ts
@@ -24,7 +24,7 @@ export type DocsSource = FileSystemSource<DocsSchema>
 
 export const DocsCollection = new Collection<DocsSchema>(
   {
-    filePattern: 'docs/**/*.mdx',
+    filePattern: '**/*.mdx',
     baseDirectory: 'docs',
     basePath: 'docs',
   },
@@ -33,7 +33,7 @@ export const DocsCollection = new Collection<DocsSchema>(
 
 export const GuidesCollection = new Collection<DocsSchema>(
   {
-    filePattern: 'guides/**/*.mdx',
+    filePattern: '**/*.mdx',
     baseDirectory: 'guides',
     basePath: 'guides',
   },
@@ -72,8 +72,8 @@ export type CollectionsSource = FileSystemSource<CollectionsSchema>
 
 export const CollectionsCollection = new Collection<CollectionsSchema>(
   {
-    filePattern: 'src/collections/*.tsx',
-    baseDirectory: 'collections',
+    filePattern: '*.tsx',
+    baseDirectory: 'src/collections',
     basePath: 'collections',
     filter: filterInternalSources,
     tsConfigFilePath: '../../packages/renoun/tsconfig.json',
@@ -94,7 +94,7 @@ type CollectionsDocsSchema = {
 
 export const CollectionsDocsCollection = new Collection<CollectionsDocsSchema>(
   {
-    filePattern: 'src/collections/docs/*.mdx',
+    filePattern: '*.mdx',
     baseDirectory: 'src/collections/docs',
     basePath: 'collections',
     schema: {
@@ -111,8 +111,8 @@ export type ComponentSource = FileSystemSource<ComponentSchema>
 
 export const ComponentsCollection = new Collection<ComponentSchema>(
   {
-    filePattern: 'src/components/**/*.{ts,tsx}',
-    baseDirectory: 'components',
+    filePattern: '**/*.{ts,tsx}',
+    baseDirectory: 'src/components',
     basePath: 'components',
     filter: filterInternalSources,
     tsConfigFilePath: '../../packages/renoun/tsconfig.json',
@@ -128,8 +128,8 @@ export const ComponentsMDXCollection = new Collection<{
   headings: Headings
 }>(
   {
-    filePattern: 'src/components/**/*.mdx',
-    baseDirectory: 'components',
+    filePattern: '**/*.mdx',
+    baseDirectory: 'src/components',
     basePath: 'components',
     tsConfigFilePath: '../../packages/renoun/tsconfig.json',
   },

--- a/apps/site/components/SiblingLink.tsx
+++ b/apps/site/components/SiblingLink.tsx
@@ -29,7 +29,11 @@ export async function SiblingLink({
   variant?: 'name' | 'title'
 }) {
   if (source.isDirectory()) {
-    return null
+    source = (await source.getSource('index')) as FileSystemSource<any>
+
+    if (!source) {
+      return null
+    }
   }
 
   const metadata = await source.getExport('metadata').getValue()

--- a/apps/site/components/SiblingLink.tsx
+++ b/apps/site/components/SiblingLink.tsx
@@ -29,11 +29,7 @@ export async function SiblingLink({
   variant?: 'name' | 'title'
 }) {
   if (source.isDirectory()) {
-    source = (await source.getSource('index')) as FileSystemSource<any>
-
-    if (!source) {
-      return null
-    }
+    return null
   }
 
   const metadata = await source.getExport('metadata').getValue()

--- a/apps/site/components/Sidebar/Sidebar.tsx
+++ b/apps/site/components/Sidebar/Sidebar.tsx
@@ -17,15 +17,12 @@ async function TreeNavigation({
   source: FileSystemSource<any>
   variant?: 'name' | 'title'
 }) {
-  const mainSource = source.isDirectory()
-    ? await source.getSource('index')
-    : source
-  const metadata = mainSource
-    ? await mainSource.getExport('metadata').getValue()
-    : null
   const sources = await source.getSources({ depth: 1 })
   const depth = source.getDepth()
   const path = source.getPath()
+  const metadata = source.isDirectory()
+    ? null
+    : await source.getExport('metadata').getValue()
 
   if (sources.length === 0) {
     return (

--- a/apps/site/components/Sidebar/Sidebar.tsx
+++ b/apps/site/components/Sidebar/Sidebar.tsx
@@ -17,10 +17,15 @@ async function TreeNavigation({
   source: FileSystemSource<any>
   variant?: 'name' | 'title'
 }) {
+  const mainSource = source.isDirectory()
+    ? await source.getSource('index')
+    : source
+  const metadata = mainSource
+    ? await mainSource.getExport('metadata').getValue()
+    : null
   const sources = await source.getSources({ depth: 1 })
   const depth = source.getDepth()
   const path = source.getPath()
-  const metadata = await source.getExport('metadata').getValue()
 
   if (sources.length === 0) {
     return (

--- a/apps/site/docs/02.getting-started.mdx
+++ b/apps/site/docs/02.getting-started.mdx
@@ -164,7 +164,7 @@ export const PostsCollection = new Collection<{
   default: MDXContent
   frontmatter: z.infer<typeof frontmatterSchema>
 }>({
-  filePattern: 'posts/*.mdx',
+  filePattern: '*.mdx',
   baseDirectory: 'posts',
   schema: {
     frontmatter: frontmatterSchema.parse,

--- a/apps/site/guides/04.zod.mdx
+++ b/apps/site/guides/04.zod.mdx
@@ -19,7 +19,8 @@ const frontmatterSchema = z.object({
 export const PostsCollection = new Collection<{
   default: MDXContent
   frontmatter: z.infer<typeof frontmatterSchema>
-}>('posts/.mdx', {
+}>({
+  filePattern: '*.mdx',
   baseDirectory: 'posts',
   schema: {
     frontmatter: frontmatterSchema.parse,
@@ -79,7 +80,8 @@ const frontmatterSchema = z.object({
 export const PostsCollection = new Collection<{
   default: MDXContent
   frontmatter: z.infer<typeof frontmatterSchema>
-}>('posts/.mdx', {
+}>({
+  filePattern: '*.mdx',
   baseDirectory: 'posts',
   schema: {
     frontmatter: frontmatterSchema.parse,

--- a/apps/site/guides/05.valibot.mdx
+++ b/apps/site/guides/05.valibot.mdx
@@ -19,7 +19,8 @@ const frontmatterSchema = v.object({
 export const PostsCollection = new Collection<{
   default: MDXContent
   frontmatter: v.InferInput<typeof frontmatterSchema>
-}>('posts/.mdx', {
+}>({
+  filePattern: '*.mdx',
   baseDirectory: 'posts',
   schema: {
     frontmatter: (value) => v.parse(frontmatterSchema, value),
@@ -79,7 +80,8 @@ const frontmatterSchema = v.object({
 export const PostsCollection = new Collection<{
   default: MDXContent
   frontmatter: v.InferInput<typeof frontmatterSchema>
-}>('posts/.mdx', {
+}>({
+  filePattern: '*.mdx',
   baseDirectory: 'posts',
   schema: {
     frontmatter: (value) => v.parse(frontmatterSchema, value),

--- a/examples/blog/collections.ts
+++ b/examples/blog/collections.ts
@@ -14,7 +14,7 @@ export const PostsCollection = new Collection<{
   frontmatter: z.infer<typeof frontmatterSchema>
 }>(
   {
-    filePattern: 'posts/*.mdx',
+    filePattern: '*.mdx',
     baseDirectory: 'posts',
     schema: {
       frontmatter: frontmatterSchema.parse,

--- a/examples/design-system/app/components/[...slug]/page.tsx
+++ b/examples/design-system/app/components/[...slug]/page.tsx
@@ -9,17 +9,14 @@ import { Stack } from '@/components'
 
 export async function generateStaticParams() {
   const sources = await ComponentsCollection.getSources()
-
-  return sources
-    .filter((source) => source.isFile())
-    .map((source) => ({ slug: source.getPathSegments() }))
+  return sources.map((source) => ({ slug: source.getPathSegments() }))
 }
 
 const ComponentsReadmeCollection = new Collection<{ default: MDXContent }>(
   {
+    filePattern: '**/README.mdx',
     baseDirectory: 'components',
     basePath: 'components',
-    filePattern: '@/components/**/README.mdx',
   },
   (slug) => import(`../../../components/${slug}.mdx`)
 )
@@ -66,10 +63,12 @@ export default async function Component({
         {Readme ? <Readme /> : null}
       </div>
 
-      <div>
-        <h2>API Reference</h2>
-        <APIReference source={componentSource} />
-      </div>
+      {isExamplesPage ? null : (
+        <div>
+          <h2>API Reference</h2>
+          <APIReference source={componentSource} />
+        </div>
+      )}
 
       {isExamplesPage || !examples ? null : (
         <div>

--- a/examples/design-system/collections.ts
+++ b/examples/design-system/collections.ts
@@ -6,9 +6,9 @@ export type ComponentSource = FileSystemSource<ComponentSchema>
 
 export const ComponentsCollection = new Collection<ComponentSchema>(
   {
+    filePattern: '**/{index,*.examples,examples/*}.{ts,tsx}',
     baseDirectory: 'components',
     basePath: 'components',
-    filePattern: '@/components/**/{index,*.examples,examples/*}.{ts,tsx}',
   },
   [
     (slug) => import(`./components/${slug}.ts`),

--- a/examples/design-system/package.json
+++ b/examples/design-system/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@examples/design-system",
   "scripts": {
-    "dev": "renoun next dev --turbopack",
+    "dev": "renoun next dev",
     "build": "next build",
     "start": "next start"
   },

--- a/packages/renoun/src/README.mdx
+++ b/packages/renoun/src/README.mdx
@@ -1,11 +1,12 @@
 # renoun
 
-The primary package for renoun that provides a utility for working with a collection of module imports.
+## Collections
 
 ```ts filename="data.ts"
-import { createSource } from 'renoun'
+import { Collection } from 'renoun/collections'
 
-export const allDocs = createSource('docs/**/*.mdx', {
+export const allDocs = new Collection({
+  filePattern: '**/*.mdx',
   baseDirectory: 'docs',
 })
 ```

--- a/packages/renoun/src/collections/docs/index.mdx
+++ b/packages/renoun/src/collections/docs/index.mdx
@@ -38,17 +38,32 @@ export const PostsCollection = new Collection(
 
 ## Configuring Collections
 
-You can specify a `baseDirectory` to trim the beginning of the generated path up to that point, and a `basePath` to define a prefix added to the generated path.
+You can specify a `baseDirectory` to trim the beginning of the generated source paths up to that point:
 
 ```ts filename="02.collections.ts"
 import { Collection } from 'renoun/collections'
 
 export const PostsCollection = new Collection({
-  filePattern: 'posts/*.mdx',
+  filePattern: '*.mdx',
+  baseDirectory: 'posts',
+})
+```
+
+In this example, the `PostsCollection` will target all MDX files within the `posts` directory and generate paths relative to the `posts` directory. This means a file system path like `posts/how-to-build-a-button-component.mdx` will be transformed into the URL path `/how-to-build-a-button-component`. Notice the `baseDirectory` is trimmed from the source path.
+
+If you want to customize the source path, you can set the `basePath` option which will prepend a path to the final generated path:
+
+```ts filename="03.collections.ts"
+import { Collection } from 'renoun/collections'
+
+export const PostsCollection = new Collection({
+  filePattern: '*.mdx',
   baseDirectory: 'posts',
   basePath: 'posts',
 })
 ```
+
+The `basePath` option is useful if you want to build custom index pages. Note, this option does not affect the query key used to [query sources](#querying-sources).
 
 ## Adding Types
 
@@ -69,7 +84,7 @@ interface PostsSchema {
 }
 
 export const PostsCollection = new Collection<PostsSchema>({
-  filePattern: 'posts/*.mdx',
+  filePattern: '*.mdx',
   baseDirectory: 'posts',
   basePath: 'posts',
 })
@@ -99,7 +114,7 @@ interface PostsSchema {
 }
 
 export const PostsCollection = new Collection<PostsSchema>({
-  filePattern: 'posts/*.mdx',
+  filePattern: '*.mdx',
   baseDirectory: 'posts',
   basePath: 'posts',
   schema: {
@@ -172,13 +187,13 @@ Let's say you have two collections, one for blog posts, and another for componen
 import { Collection, CompositeCollection } from 'renoun/collections'
 
 const PostsCollection = new Collection({
-  filePattern: 'posts/*.mdx',
+  filePattern: '*.mdx',
   baseDirectory: 'posts',
 })
 
 const ComponentsCollection = new Collection({
-  filePattern: 'src/components/**/*.{ts,tsx}',
-  baseDirectory: 'components',
+  filePattern: '**/*.{ts,tsx}',
+  baseDirectory: 'src/components',
 })
 
 const AllCollections = new CompositeCollection(

--- a/packages/renoun/src/collections/index.test.ts
+++ b/packages/renoun/src/collections/index.test.ts
@@ -73,12 +73,11 @@ describe('collections', () => {
 
     async function buildTreeNavigation(source: FileSystemSource<any>) {
       const path = source.getPath()
+      const sources = await source.getSources({ depth: 1 })
 
-      if (source.isFile()) {
+      if (sources.length === 0) {
         return path
       }
-
-      const sources = await source.getSources({ depth: 1 })
 
       return {
         path,
@@ -106,10 +105,7 @@ describe('collections', () => {
         "/git-provider",
         "/mdx-components",
         "/mdx-content",
-        {
-          "children": [],
-          "path": "/package-install",
-        },
+        "/package-install",
         "/rendered-html",
       ]
     `)

--- a/packages/renoun/src/collections/index.tsx
+++ b/packages/renoun/src/collections/index.tsx
@@ -8,7 +8,7 @@ import type {
 } from 'ts-morph'
 import tsMorph from 'ts-morph'
 import { readFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { dirname, resolve, join } from 'node:path'
 import globParent from 'glob-parent'
 import { minimatch } from 'minimatch'
 
@@ -371,7 +371,7 @@ class Export<Value, AllExports extends FileExports = FileExports>
 
     const filePath =
       process.env.NODE_ENV === 'development'
-        ? this.source._getSourceFile().getFilePath()
+        ? this.exportDeclaration.getSourceFile().getFilePath()
         : getDeclarationLocation(this.exportDeclaration).filePath
 
     return filePath
@@ -644,7 +644,7 @@ class Source<AllExports extends FileExports>
     return gitMetadata.authors
   }
 
-  getSource(path: string | string[]) {
+  getSource(path: string | string[] = 'index') {
     const currentPath = this.getPath()
     const fullPath = Array.isArray(path)
       ? `${currentPath}/${path.join('/')}`
@@ -663,18 +663,36 @@ class Source<AllExports extends FileExports>
     const currentPath = this.getPath()
     const currentDepth = this.getDepth()
     const maxDepth = depth === Infinity ? Infinity : currentDepth + depth
+    const fileSystemSources = await this.collection._getFileSystemSources()
+    const seenPaths = new Set<string>()
+    let previousDirectoryName: string
 
-    return (await this.collection._getFileSystemSources()).filter((source) => {
-      if (source) {
-        const descendantPath = source.getPath()
-        const descendantDepth = source.getDepth()
-
-        return (
-          descendantPath.startsWith(currentPath) &&
-          descendantDepth > currentDepth &&
-          descendantDepth <= maxDepth
-        )
+    return fileSystemSources.filter((source) => {
+      // Account for index/readme files and files that have the same base name but different suffixes/extensions e.g. Button.tsx, Button.test.tsx
+      const sourcePath = source.getPath()
+      if (seenPaths.has(sourcePath)) {
+        return false
       }
+      seenPaths.add(sourcePath)
+
+      const descendantPath = source.getPath()
+
+      // Skip sources that are not descendants
+      if (!descendantPath.startsWith(currentPath)) {
+        return
+      }
+
+      const descendantDepth = source.getDepth()
+
+      // Skip sources that are the same name as the previous directory name
+      if (source.getName() === previousDirectoryName) {
+        return false
+      }
+      if (source.isDirectory()) {
+        previousDirectoryName = source.getName()
+      }
+
+      return descendantDepth > currentDepth && descendantDepth <= maxDepth
     }) as FileSystemSource<AllExports>[]
   }
 
@@ -837,13 +855,15 @@ export class Collection<AllExports extends FileExports>
     options: CollectionOptions<AllExports>,
     getImport?: GetImport | GetImport[]
   ) {
-    // TODO: add better validation for options
-    if (
-      options.baseDirectory &&
-      !options.filePattern.startsWith(options.baseDirectory)
-    ) {
-      throw new Error(
-        `[renoun] The "baseDirectory" option "${options.baseDirectory}" must be included in the file pattern "${options.filePattern}".`
+    this.options = options
+
+    // Ensure the base directory is resolved relative to the tsconfig file path if provided.
+    if (options.baseDirectory) {
+      this.options.baseDirectory = resolve(
+        options.tsConfigFilePath
+          ? dirname(options.tsConfigFilePath)
+          : process.cwd(),
+        options.baseDirectory
       )
     }
 
@@ -851,7 +871,6 @@ export class Collection<AllExports extends FileExports>
       options.tsConfigFilePath = 'tsconfig.json'
     }
 
-    this.options = options
     this._getImport = getImport!
     this._project = getProject({ tsConfigFilePath: options.tsConfigFilePath })
 
@@ -865,17 +884,23 @@ export class Collection<AllExports extends FileExports>
         : {}
     this._tsConfigDirectory = tsConfigDirectory
 
-    const resolvedGlobPattern =
+    const filePatternWithBaseDirectory = this.options.baseDirectory
+      ? join(this.options.baseDirectory, options.filePattern)
+      : options.filePattern
+    const resolvedFilePattern = resolve(
+      tsConfigDirectory,
       compilerOptions.baseUrl && compilerOptions.paths
         ? resolveTsConfigPath(
             tsConfigFilePath,
             compilerOptions.baseUrl,
             compilerOptions.paths,
-            options.filePattern
+            filePatternWithBaseDirectory
           )
-        : options.filePattern
-    this._absoluteGlobPattern = resolve(tsConfigDirectory, resolvedGlobPattern)
-    this._absoluteBaseGlobPattern = globParent(this._absoluteGlobPattern)
+        : filePatternWithBaseDirectory
+    )
+
+    this._absoluteGlobPattern = resolvedFilePattern
+    this._absoluteBaseGlobPattern = globParent(resolvedFilePattern)
 
     const fileSystemSources = getSourceFilesAndDirectories(
       this._project,
@@ -898,11 +923,11 @@ export class Collection<AllExports extends FileExports>
       throw new Error(
         `[renoun] No source files or directories were found for the file pattern: ${options.filePattern}
 
-You can fix this error by ensuring the following:
-  
-  ${filePatternMessage}
-  - If using a relative path, ensure the "tsConfigFilePath" option is targeting the correct workspace.
-  - If you continue to see this error, please file an issue: https://github.com/souporserious/renoun/issues\n`
+    You can fix this error by ensuring the following:
+
+      ${filePatternMessage}
+      - If using a relative path, ensure the "tsConfigFilePath" option is targeting the correct workspace.
+      - If you continue to see this error, please file an issue: https://github.com/souporserious/renoun/issues\n`
       )
     }
 
@@ -921,12 +946,12 @@ You can fix this error by ensuring the following:
       )
     )
 
-    const baseDirectory = this._project.getDirectoryOrThrow(
+    const projectRootDirectory = this._project.getDirectoryOrThrow(
       this._absoluteBaseGlobPattern
     )
-    this._sourceFilesOrderMap = getSourceFilesOrderMap(baseDirectory)
-    this._sourcePathMap = getSourceFilesPathMap(baseDirectory, {
-      baseDirectory: options.baseDirectory,
+    this._sourceFilesOrderMap = getSourceFilesOrderMap(projectRootDirectory)
+    this._sourcePathMap = getSourceFilesPathMap(projectRootDirectory, {
+      baseDirectory: this.options.baseDirectory,
       basePath: options.basePath,
     })
   }
@@ -947,20 +972,11 @@ You can fix this error by ensuring the following:
 
   async _getFileSystemSources(compositeCollection?: CompositeCollection<any>) {
     const resolvedSources = await Promise.all(
-      this._fileSystemSources.map((fileSystemSource) => {
-        // Filter out directories that have an index or readme file
-        if (fileSystemSource instanceof tsMorph.Directory) {
-          const directorySourceFile = getDirectorySourceFile(fileSystemSource)
-
-          if (directorySourceFile) {
-            return
-          }
-        }
-
-        return this._getFileSystemSource(fileSystemSource, compositeCollection)
-      })
+      this._fileSystemSources.map((fileSystemSource) =>
+        this._getFileSystemSource(fileSystemSource, compositeCollection)
+      )
     )
-    const sources = resolvedSources.filter((source) => {
+    const filteredSources = resolvedSources.filter((source) => {
       if (source) {
         // filter based on ignored files in tsconfig
         if (this._tsConfig.exclude.length) {
@@ -990,7 +1006,7 @@ You can fix this error by ensuring the following:
     }) as FileSystemSource<AllExports>[]
 
     try {
-      const sourcesCount = sources.length
+      const sourcesCount = filteredSources.length
 
       for (let sourceIndex = 0; sourceIndex < sourcesCount - 1; sourceIndex++) {
         for (
@@ -998,13 +1014,13 @@ You can fix this error by ensuring the following:
           sourceCompareIndex < sourcesCount - 1 - sourceIndex;
           sourceCompareIndex++
         ) {
-          const aSource = sources[sourceCompareIndex]
-          const bSource = sources[sourceCompareIndex + 1]
+          const aSource = filteredSources[sourceCompareIndex]
+          const bSource = filteredSources[sourceCompareIndex + 1]
 
           if (this.options.sort) {
             if ((await this.options.sort(aSource, bSource)) > 0) {
-              sources[sourceCompareIndex] = bSource
-              sources[sourceCompareIndex + 1] = aSource
+              filteredSources[sourceCompareIndex] = bSource
+              filteredSources[sourceCompareIndex + 1] = aSource
             }
           } else {
             // sort by order if no sort function is provided
@@ -1012,8 +1028,8 @@ You can fix this error by ensuring the following:
             const bOrder = bSource.getOrder()
 
             if (aOrder.localeCompare(bOrder) > 0) {
-              sources[sourceCompareIndex] = bSource
-              sources[sourceCompareIndex + 1] = aSource
+              filteredSources[sourceCompareIndex] = bSource
+              filteredSources[sourceCompareIndex + 1] = aSource
             }
           }
         }
@@ -1030,7 +1046,7 @@ You can fix this error by ensuring the following:
       throw error
     }
 
-    return sources
+    return filteredSources
   }
 
   _getImportSlug(source: SourceFile | Directory) {
@@ -1080,22 +1096,14 @@ You can fix this error by ensuring the following:
       return this.#sources.get(pathString)
     }
 
-    let sourceFileOrDirectory = this._fileSystemSources.find((source) => {
+    const sourceFileOrDirectory = this._fileSystemSources.find((source) => {
       const fileSystemSourcePath = getFileSystemSourcePath(source)
       const sourcePath = this._sourcePathMap.get(fileSystemSourcePath)
       return sourcePath === pathString
     })
 
-    if (sourceFileOrDirectory instanceof tsMorph.Directory) {
-      const directorySourceFile = getDirectorySourceFile(sourceFileOrDirectory)
-
-      if (directorySourceFile) {
-        sourceFileOrDirectory = directorySourceFile
-      }
-    }
-
     if (!sourceFileOrDirectory) {
-      return undefined
+      return
     }
 
     const source = new Source(this, compositeCollection, sourceFileOrDirectory)
@@ -1119,17 +1127,26 @@ You can fix this error by ensuring the following:
     const minDepth = this.getDepth()
     const maxDepth = depth === Infinity ? Infinity : minDepth + depth
     const seenPaths = new Set<string>()
+    let previousDirectoryName: string
 
     return sources.filter((source) => {
-      // Account for files that have the same base name but different suffixes/extensions e.g. Button.tsx, Button.test.tsx
+      // Account for index/readme files and files that have the same base name but different members/extensions e.g. Button.tsx, Button.test.tsx
       const sourcePath = source.getPath()
       if (seenPaths.has(sourcePath)) {
         return false
       }
       seenPaths.add(sourcePath)
 
+      // Skip sources that are the same name as the previous directory name
+      if (source.getName() === previousDirectoryName) {
+        return false
+      }
+      if (source.isDirectory()) {
+        previousDirectoryName = source.getName()
+      }
+
       const descendantDepth = source.getDepth()
-      return descendantDepth >= minDepth && descendantDepth <= maxDepth
+      return descendantDepth > minDepth && descendantDepth <= maxDepth
     }) as FileSystemSource<AllExports>[]
   }
 

--- a/packages/renoun/src/components/APIReference.tsx
+++ b/packages/renoun/src/components/APIReference.tsx
@@ -67,6 +67,15 @@ async function APIReferenceAsync({
 
     if (typeof source === 'string') {
       filePath = source
+    } else if (source.isDirectory()) {
+      const indexSource = await source.getSource('index')
+      if (indexSource) {
+        filePath = indexSource.getFileSystemPath()
+      } else {
+        throw new Error(
+          `[renoun] The source "${source.getFileSystemPath()}" does not have an associated index file.`
+        )
+      }
     } else {
       filePath = source.getFileSystemPath()
     }

--- a/packages/renoun/src/utils/file-path-to-pathname.test.ts
+++ b/packages/renoun/src/utils/file-path-to-pathname.test.ts
@@ -5,7 +5,7 @@ import { filePathToPathname } from './file-path-to-pathname.js'
 
 const workingDirectory = '/Users/username/Code/renoun/site'
 
-describe('filePathToUrlPathname', () => {
+describe('filePathToPathname', () => {
   beforeEach(() => {
     vi.spyOn(process, 'cwd').mockReturnValue(workingDirectory)
   })
@@ -66,7 +66,7 @@ describe('filePathToUrlPathname', () => {
 
   test('handles the same directory and base name', () => {
     expect(filePathToPathname('src/components/Button/Button.tsx', 'src')).toBe(
-      '/components/button/button'
+      '/components/button'
     )
   })
 
@@ -140,7 +140,7 @@ describe('filePathToUrlPathname', () => {
   test('directory, file name, and file name member', () => {
     expect(
       filePathToPathname('src/components/Button/Button/examples', 'src')
-    ).toBe('/components/button/button/examples')
+    ).toBe('/components/button/examples')
 
     expect(
       filePathToPathname('src/components/Button/examples.tsx', 'src')
@@ -148,6 +148,6 @@ describe('filePathToUrlPathname', () => {
 
     expect(
       filePathToPathname('src/components/Button/Button.examples.tsx', 'src')
-    ).toBe('/components/button/button/examples')
+    ).toBe('/components/button/examples')
   })
 })

--- a/packages/renoun/src/utils/file-path-to-pathname.test.ts
+++ b/packages/renoun/src/utils/file-path-to-pathname.test.ts
@@ -18,7 +18,7 @@ describe('filePathToUrlPathname', () => {
     expect(
       filePathToPathname(
         join(workingDirectory, 'src/components/Code.tsx'),
-        'src'
+        join(workingDirectory, 'src')
       )
     ).toBe('/components/code')
   })
@@ -26,131 +26,96 @@ describe('filePathToUrlPathname', () => {
   test('removes sorting numbers', () => {
     expect(
       filePathToPathname(
-        join(workingDirectory, 'docs/examples/02.authoring.mdx')
+        join(workingDirectory, 'docs/examples/02.authoring.mdx'),
+        workingDirectory
       )
     ).toBe('/docs/examples/authoring')
   })
 
   test('directory index', () => {
     expect(
-      filePathToPathname(
-        join(workingDirectory, 'src/collections/index.tsx'),
-        'src/collections'
-      )
+      filePathToPathname('src/collections/index.tsx', 'src/collections')
     ).toBe('/index')
   })
 
   test('uses base pathname', () => {
-    expect(
-      filePathToPathname(
-        join(workingDirectory, 'src/index.tsx'),
-        'src',
-        'components'
-      )
-    ).toBe('/components/index')
+    expect(filePathToPathname('src/index.tsx', 'src', 'components')).toBe(
+      '/components/index'
+    )
   })
 
   test('trims base directory', () => {
-    expect(
-      filePathToPathname(
-        join(workingDirectory, 'src/components/index.tsx'),
-        'src'
-      )
-    ).toBe('/components/index')
+    expect(filePathToPathname('src/components/index.tsx', 'src')).toBe(
+      '/components/index'
+    )
 
-    expect(
-      filePathToPathname(join(workingDirectory, 'src/utils/index.js'), 'src')
-    ).toBe('/utils/index')
+    expect(filePathToPathname('src/utils/index.js', 'src')).toBe('/utils/index')
   })
 
   test('accounts for base directory', () => {
     expect(
-      filePathToPathname(
-        join(workingDirectory, '../../src/components/index.tsx'),
-        '../../src'
-      )
+      filePathToPathname('../../src/components/index.tsx', '../../src')
     ).toBe('/components/index')
   })
 
   test('errors for bad base directory', () => {
     expect(() => {
-      filePathToPathname(
-        join(workingDirectory, 'src/components/index.ts'),
-        'src/utils'
-      )
+      filePathToPathname('src/components/index.ts', 'src/utils')
     }).toThrowError()
   })
 
   test('handles the same directory and base name', () => {
-    expect(
-      filePathToPathname(
-        join(workingDirectory, 'src/components/Button/Button.tsx'),
-        'src'
-      )
-    ).toBe('/components/button/button')
+    expect(filePathToPathname('src/components/Button/Button.tsx', 'src')).toBe(
+      '/components/button/button'
+    )
   })
 
   test('normalizes relative paths', () => {
     expect(
       filePathToPathname(
         join(workingDirectory, '../packages/renoun/src/components/index.ts'),
-        '../packages/renoun/src'
+        join(workingDirectory, '../packages/renoun/src')
       )
     ).toBe('/components/index')
   })
 
   test('handles upper case filenames', () => {
-    expect(
-      filePathToPathname(
-        join(workingDirectory, 'src/components/MDX.tsx'),
-        'src'
-      )
-    ).toBe('/components/mdx')
+    expect(filePathToPathname('src/components/MDX.tsx', 'src')).toBe(
+      '/components/mdx'
+    )
 
-    expect(
-      filePathToPathname(
-        join(workingDirectory, 'src/components/MDXProvider.tsx'),
-        'src'
-      )
-    ).toBe('/components/mdx-provider')
+    expect(filePathToPathname('src/components/MDXProvider.tsx', 'src')).toBe(
+      '/components/mdx-provider'
+    )
   })
 
   test('handles pascal case filenames', () => {
-    expect(
-      filePathToPathname(
-        join(workingDirectory, 'src/components/CodeBlock.tsx'),
-        'src'
-      )
-    ).toBe('/components/code-block')
+    expect(filePathToPathname('src/components/CodeBlock.tsx', 'src')).toBe(
+      '/components/code-block'
+    )
   })
 
   test('handles camel case filenames', () => {
-    expect(
-      filePathToPathname(join(workingDirectory, 'src/hooks/useHover.ts'), 'src')
-    ).toBe('/hooks/use-hover')
+    expect(filePathToPathname('src/hooks/useHover.ts', 'src')).toBe(
+      '/hooks/use-hover'
+    )
   })
 
   test('handles nested paths with the same name as base directory', () => {
     expect(
       filePathToPathname(
-        join(workingDirectory, 'content/content_1/section_1/01.page-1.mdx'),
+        'content/content_1/section_1/01.page-1.mdx',
         'content/'
       )
     ).toBe('/content-1/section-1/page-1')
 
     expect(
-      filePathToPathname(
-        join(workingDirectory, 'content/content_1/section_1/01.page-1.mdx'),
-        'content'
-      )
+      filePathToPathname('content/content_1/section_1/01.page-1.mdx', 'content')
     ).toBe('/content-1/section-1/page-1')
 
     expect(
       filePathToPathname(
-        join(
-          workingDirectory,
-          '/src/content/content_1/section_1/01.page-1.mdx'
-        ),
+        '/src/content/content_1/section_1/01.page-1.mdx',
         '/src/content'
       )
     ).toBe('/content-1/section-1/page-1')
@@ -158,49 +123,31 @@ describe('filePathToUrlPathname', () => {
 
   test('replaces base directory with base pathname', () => {
     expect(
-      filePathToPathname(
-        join(workingDirectory, '/src/posts/getting-started.mdx'),
-        '/src/posts',
-        'blog'
-      )
+      filePathToPathname('/src/posts/getting-started.mdx', '/src/posts', 'blog')
     ).toBe('/blog/getting-started')
   })
 
   test('removes working directory', () => {
-    expect(filePathToPathname(workingDirectory + '/src/hooks/index.tsx')).toBe(
-      '/src/hooks/index'
-    )
+    expect(filePathToPathname('/src/hooks/index.tsx')).toBe('/src/hooks/index')
   })
 
   test('file name member', () => {
-    expect(
-      filePathToPathname(
-        join(workingDirectory, 'src/components/Button.tests.tsx'),
-        'src'
-      )
-    ).toBe('/components/button/tests')
+    expect(filePathToPathname('src/components/Button.tests.tsx', 'src')).toBe(
+      '/components/button/tests'
+    )
   })
 
   test('directory, file name, and file name member', () => {
     expect(
-      filePathToPathname(
-        join(workingDirectory, 'src/components/Button/Button/examples'),
-        'src'
-      )
+      filePathToPathname('src/components/Button/Button/examples', 'src')
     ).toBe('/components/button/button/examples')
 
     expect(
-      filePathToPathname(
-        join(workingDirectory, 'src/components/Button/examples.tsx'),
-        'src'
-      )
+      filePathToPathname('src/components/Button/examples.tsx', 'src')
     ).toBe('/components/button/examples')
 
     expect(
-      filePathToPathname(
-        join(workingDirectory, 'src/components/Button/Button.examples.tsx'),
-        'src'
-      )
+      filePathToPathname('src/components/Button/Button.examples.tsx', 'src')
     ).toBe('/components/button/button/examples')
   })
 })

--- a/packages/renoun/src/utils/file-path-to-pathname.test.ts
+++ b/packages/renoun/src/utils/file-path-to-pathname.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, afterEach, describe, test, expect, vi } from 'vitest'
-import { resolve } from 'node:path'
+import { join } from 'node:path'
 
 import { filePathToPathname } from './file-path-to-pathname.js'
 
@@ -16,122 +16,141 @@ describe('filePathToUrlPathname', () => {
 
   test('converts a file system path to a URL-friendly pathname', () => {
     expect(
-      filePathToPathname(workingDirectory + '/src/components/Code.tsx', 'src')
+      filePathToPathname(
+        join(workingDirectory, 'src/components/Code.tsx'),
+        'src'
+      )
     ).toBe('/components/code')
   })
 
   test('removes sorting numbers', () => {
-    expect(filePathToPathname('docs/examples/02.authoring.mdx')).toBe(
-      '/docs/examples/authoring'
-    )
-  })
-
-  test('uses package name for index', () => {
     expect(
       filePathToPathname(
-        workingDirectory + '/src/index.ts',
-        'src',
-        undefined,
-        'renoun'
+        join(workingDirectory, 'docs/examples/02.authoring.mdx')
       )
-    ).toBe('/renoun')
-
-    expect(filePathToPathname('src/utils/index.js', 'utils')).toBe('/utils')
+    ).toBe('/docs/examples/authoring')
   })
 
-  test('uses base pathname for index', () => {
+  test('directory index', () => {
     expect(
       filePathToPathname(
-        workingDirectory + '/src/index.tsx',
+        join(workingDirectory, 'src/collections/index.tsx'),
+        'src/collections'
+      )
+    ).toBe('/index')
+  })
+
+  test('uses base pathname', () => {
+    expect(
+      filePathToPathname(
+        join(workingDirectory, 'src/index.tsx'),
         'src',
         'components'
       )
-    ).toBe('/components')
+    ).toBe('/components/index')
   })
 
-  test('uses base directory for index', () => {
+  test('trims base directory', () => {
     expect(
       filePathToPathname(
-        workingDirectory + '/src/components/index.tsx',
-        'components'
+        join(workingDirectory, 'src/components/index.tsx'),
+        'src'
       )
-    ).toBe('/components')
-
-    expect(filePathToPathname('src/utils/index.js', 'utils')).toBe('/utils')
-  })
-
-  test('uses directory for readme', () => {
-    expect(filePathToPathname('renoun/src/components/readme.md')).toBe(
-      '/renoun/src/components'
-    )
+    ).toBe('/components/index')
 
     expect(
-      filePathToPathname(
-        workingDirectory + '/src/README.mdx',
-        'src',
-        'packages'
-      )
-    ).toBe('/packages')
+      filePathToPathname(join(workingDirectory, 'src/utils/index.js'), 'src')
+    ).toBe('/utils/index')
   })
 
   test('accounts for base directory', () => {
-    expect(filePathToPathname('../../src/components/index.tsx', 'src')).toBe(
-      '/components'
-    )
+    expect(
+      filePathToPathname(
+        join(workingDirectory, '../../src/components/index.tsx'),
+        '../../src'
+      )
+    ).toBe('/components/index')
+  })
+
+  test('errors for bad base directory', () => {
+    expect(() => {
+      filePathToPathname(
+        join(workingDirectory, 'src/components/index.ts'),
+        'src/utils'
+      )
+    }).toThrowError()
   })
 
   test('handles the same directory and base name', () => {
-    expect(filePathToPathname('src/components/Button/Button.tsx', 'src')).toBe(
-      '/components/button'
-    )
+    expect(
+      filePathToPathname(
+        join(workingDirectory, 'src/components/Button/Button.tsx'),
+        'src'
+      )
+    ).toBe('/components/button/button')
   })
 
   test('normalizes relative paths', () => {
     expect(
       filePathToPathname(
-        resolve(workingDirectory, '../packages/renoun/src/components/index.ts'),
+        join(workingDirectory, '../packages/renoun/src/components/index.ts'),
         '../packages/renoun/src'
       )
-    ).toBe('/components')
+    ).toBe('/components/index')
   })
 
   test('handles upper case filenames', () => {
-    expect(filePathToPathname('src/components/MDX.tsx', 'src')).toBe(
-      '/components/mdx'
-    )
+    expect(
+      filePathToPathname(
+        join(workingDirectory, 'src/components/MDX.tsx'),
+        'src'
+      )
+    ).toBe('/components/mdx')
 
-    expect(filePathToPathname('src/components/MDXProvider.tsx', 'src')).toBe(
-      '/components/mdx-provider'
-    )
+    expect(
+      filePathToPathname(
+        join(workingDirectory, 'src/components/MDXProvider.tsx'),
+        'src'
+      )
+    ).toBe('/components/mdx-provider')
   })
 
   test('handles pascal case filenames', () => {
-    expect(filePathToPathname('src/components/CodeBlock.tsx', 'src')).toBe(
-      '/components/code-block'
-    )
+    expect(
+      filePathToPathname(
+        join(workingDirectory, 'src/components/CodeBlock.tsx'),
+        'src'
+      )
+    ).toBe('/components/code-block')
   })
 
   test('handles camel case filenames', () => {
-    expect(filePathToPathname('src/hooks/useHover.ts', 'src')).toBe(
-      '/hooks/use-hover'
-    )
+    expect(
+      filePathToPathname(join(workingDirectory, 'src/hooks/useHover.ts'), 'src')
+    ).toBe('/hooks/use-hover')
   })
 
   test('handles nested paths with the same name as base directory', () => {
     expect(
       filePathToPathname(
-        'content/content_1/section_1/01.page-1.mdx',
+        join(workingDirectory, 'content/content_1/section_1/01.page-1.mdx'),
         'content/'
       )
     ).toBe('/content-1/section-1/page-1')
 
     expect(
-      filePathToPathname('content/content_1/section_1/01.page-1.mdx', 'content')
+      filePathToPathname(
+        join(workingDirectory, 'content/content_1/section_1/01.page-1.mdx'),
+        'content'
+      )
     ).toBe('/content-1/section-1/page-1')
 
     expect(
       filePathToPathname(
-        '/src/content/content_1/section_1/01.page-1.mdx',
+        join(
+          workingDirectory,
+          '/src/content/content_1/section_1/01.page-1.mdx'
+        ),
         '/src/content'
       )
     ).toBe('/content-1/section-1/page-1')
@@ -139,44 +158,49 @@ describe('filePathToUrlPathname', () => {
 
   test('replaces base directory with base pathname', () => {
     expect(
-      filePathToPathname('/src/posts/getting-started.mdx', 'posts', 'blog')
+      filePathToPathname(
+        join(workingDirectory, '/src/posts/getting-started.mdx'),
+        '/src/posts',
+        'blog'
+      )
     ).toBe('/blog/getting-started')
   })
 
   test('removes working directory', () => {
     expect(filePathToPathname(workingDirectory + '/src/hooks/index.tsx')).toBe(
-      '/src/hooks'
+      '/src/hooks/index'
     )
-  })
-
-  test('handles base directory, base pathname, and package name', () => {
-    expect(
-      filePathToPathname(
-        resolve(workingDirectory, '../packages/renoun/src/index.ts'),
-        '../packages/renoun/src',
-        'packages',
-        'renoun'
-      )
-    ).toBe('/packages/renoun')
   })
 
   test('file name member', () => {
-    expect(filePathToPathname('src/components/Button.tests.tsx', 'src')).toBe(
-      '/components/button/tests'
-    )
+    expect(
+      filePathToPathname(
+        join(workingDirectory, 'src/components/Button.tests.tsx'),
+        'src'
+      )
+    ).toBe('/components/button/tests')
   })
 
   test('directory, file name, and file name member', () => {
     expect(
-      filePathToPathname('src/components/Button/Button/examples', 'src')
+      filePathToPathname(
+        join(workingDirectory, 'src/components/Button/Button/examples'),
+        'src'
+      )
+    ).toBe('/components/button/button/examples')
+
+    expect(
+      filePathToPathname(
+        join(workingDirectory, 'src/components/Button/examples.tsx'),
+        'src'
+      )
     ).toBe('/components/button/examples')
 
     expect(
-      filePathToPathname('src/components/Button/examples.tsx', 'src')
-    ).toBe('/components/button/examples')
-
-    expect(
-      filePathToPathname('src/components/Button/Button.examples.tsx', 'src')
-    ).toBe('/components/button/examples')
+      filePathToPathname(
+        join(workingDirectory, 'src/components/Button/Button.examples.tsx'),
+        'src'
+      )
+    ).toBe('/components/button/button/examples')
   })
 })

--- a/packages/renoun/src/utils/file-path-to-pathname.ts
+++ b/packages/renoun/src/utils/file-path-to-pathname.ts
@@ -1,4 +1,4 @@
-import { resolve, posix } from 'node:path'
+import { posix, join } from 'node:path'
 
 import { createSlug } from './create-slug.js'
 
@@ -7,14 +7,11 @@ export function filePathToPathname(
   /** The file path to convert. */
   filePath: string,
 
-  /** The base directory to remove from the file path. */
+  /** The absolute base directory to remove from the file path. */
   baseDirectory?: string,
 
   /** The base pathname to prepend to the file path. */
   basePathname?: string,
-
-  /** The package name to use for index and readme paths. */
-  packageName?: string,
 
   /** Whether or not to convert the pathname to kebab case. */
   kebabCase = true
@@ -23,41 +20,30 @@ export function filePathToPathname(
     return ''
   }
 
-  // First, normalize the file path
-  let baseFilePath: string = filePath
-    // Remove leading sorting number "01."
-    .replace(/\/\d+\./g, posix.sep)
-    // Remove file extensions
-    .replace(/\.[^/.]+$/, '')
-
-  // Calculate the base file path
-  if (baseDirectory) {
-    // Convert relative base directory paths to absolute paths
-    if (baseDirectory?.startsWith('.')) {
-      baseDirectory = resolve(process.cwd(), baseDirectory)
-    }
-
-    // Ensure that there is a trailing separator
-    const normalizedFilePath = baseFilePath.replace(/\/$|$/, posix.sep)
-    const normalizedBaseDirectory = baseDirectory.replace(/\/$|$/, posix.sep)
-
-    // Remove the base directory from the file path
-    ;[, baseFilePath] = normalizedFilePath.split(normalizedBaseDirectory)
-
-    // Default to an empty string if the base directory is not found
-    if (!baseFilePath) {
-      baseFilePath = ''
-    }
-  } else {
-    baseFilePath = baseFilePath.replace(process.cwd(), '')
+  if (baseDirectory && !filePath.startsWith(baseDirectory)) {
+    throw new Error(
+      `The base directory "${baseDirectory}" is not formatted correctly. It must be a parent directory path of the file path "${filePath}".`
+    )
   }
 
-  let segments = baseFilePath.split(posix.sep).filter(Boolean)
+  const baseFilePath = baseDirectory
+    ? filePath.replace(baseDirectory, '')
+    : filePath
+
+  // Split the remaining file path into segments
+  let segments = baseFilePath
+    .split(posix.sep)
+    .map((segment) =>
+      segment
+        // Remove leading sorting number "01."
+        .replace(/^\d+\./, '')
+        // Remove file extension
+        .replace(/\.[a-z]+$/, '')
+    )
+    .filter(Boolean)
 
   // Extract the segment member if present
-  // filename: "Button/Button.examples.tsx" -> "examples"
-  // directory: "Button/examples.tsx" -> "examples"
-  // sub-directory: "Button/examples/Basic.tsx" -> "examples"
+  // e.g. "Button/Button.examples.tsx" -> "examples"
   const lastSegment = segments.pop()
   if (lastSegment?.includes('.')) {
     const [baseName, member] = lastSegment.split('.')
@@ -66,54 +52,9 @@ export function filePathToPathname(
     segments.push(lastSegment)
   }
 
-  // Remove consecutive duplicate segments (e.g. "Button/Button.tsx")
-  if (segments.length > 1) {
-    segments = segments.reduce((result, segment) => {
-      if (result.at(-1) !== segment) {
-        result.push(segment)
-      }
-      return result
-    }, [] as string[])
-  }
-
   // Prepend the base pathname if defined
   if (basePathname) {
     segments.unshift(basePathname)
-  }
-
-  const baseIndex = segments.findIndex(
-    (segment) => segment === basePathname || segment === baseDirectory
-  )
-  const filteredSegments = segments
-    .slice(baseIndex + 1)
-    .map((segment) => segment.toLowerCase())
-
-  // Trim index and readme from the end of the path
-  const baseSegment = segments.at(-1)?.toLowerCase()
-
-  if (baseSegment === 'index' || baseSegment === 'readme') {
-    segments = segments.slice(0, -1)
-  }
-
-  // Use directory for root index and readme
-  if (
-    filteredSegments.length === 1 &&
-    (filteredSegments.includes('index') || filteredSegments.includes('readme'))
-  ) {
-    if (packageName) {
-      segments = segments.concat(packageName)
-    } else if (basePathname) {
-      segments =
-        segments.at(-1) === basePathname
-          ? segments
-          : segments.concat(basePathname)
-    } else if (baseDirectory) {
-      segments = segments.concat(baseDirectory)
-    } else {
-      throw new Error(
-        `[renoun] Cannot determine base path for file path "${filePath}". Provide a base directory or base path.`
-      )
-    }
   }
 
   // Convert camel and pascal case names to kebab case for case-insensitive paths

--- a/packages/renoun/src/utils/file-path-to-pathname.ts
+++ b/packages/renoun/src/utils/file-path-to-pathname.ts
@@ -52,6 +52,16 @@ export function filePathToPathname(
     segments.push(lastSegment)
   }
 
+  // Remove consecutive duplicate segments (e.g. "Button/Button.tsx")
+  if (segments.length > 1) {
+    segments = segments.reduce((result, segment) => {
+      if (result.at(-1) !== segment) {
+        result.push(segment)
+      }
+      return result
+    }, [] as string[])
+  }
+
   // Prepend the base pathname if defined
   if (basePathname) {
     segments.unshift(basePathname)

--- a/packages/renoun/src/utils/get-directory-source-file.test.ts
+++ b/packages/renoun/src/utils/get-directory-source-file.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect } from 'vitest'
+import { Project } from 'ts-morph'
+
+import { getDirectorySourceFile } from './get-directory-source-file'
+
+describe('getDirectorySourceFile', () => {
+  test('returns index file', () => {
+    const project = new Project({ useInMemoryFileSystem: true })
+    const directory = project.createDirectory('Button')
+    const sourceFile = directory.createSourceFile('index.ts')
+    const result = getDirectorySourceFile(directory, ['ts'])
+
+    expect(result).toBe(sourceFile)
+  })
+
+  test('returns README file', () => {
+    const project = new Project({ useInMemoryFileSystem: true })
+    const directory = project.createDirectory('Button')
+    const sourceFile = directory.createSourceFile('README.md')
+    const result = getDirectorySourceFile(directory, ['md'])
+
+    expect(result).toBe(sourceFile)
+  })
+
+  test('returns file with the same name as the directory', () => {
+    const project = new Project({ useInMemoryFileSystem: true })
+    const directory = project.createDirectory('Button')
+    const sourceFile = directory.createSourceFile('Button.mdx')
+    const result = getDirectorySourceFile(directory, ['mdx'])
+
+    expect(result).toBe(sourceFile)
+  })
+
+  test('gives priority to the directory-named file over index or README', () => {
+    const project = new Project({ useInMemoryFileSystem: true })
+    const directory = project.createDirectory('Button')
+    directory.createSourceFile('index.ts')
+    directory.createSourceFile('README.md')
+    const sourceFile = directory.createSourceFile('Button.mdx')
+    const result = getDirectorySourceFile(directory, ['ts', 'md', 'mdx'])
+
+    expect(result).toBe(sourceFile)
+  })
+
+  test('returns undefined if no files match the valid extensions', () => {
+    const project = new Project({ useInMemoryFileSystem: true })
+    const directory = project.createDirectory('Button')
+    directory.createSourceFile('index.js')
+    directory.createSourceFile('README.txt')
+    const result = getDirectorySourceFile(directory, ['ts', 'md'])
+
+    expect(result).toBeUndefined()
+  })
+
+  test('returns the first matching file if multiple valid files exist', () => {
+    const project = new Project({ useInMemoryFileSystem: true })
+    const directory = project.createDirectory('Button')
+    const indexFile = directory.createSourceFile('index.ts')
+    directory.createSourceFile('README.md')
+    const result = getDirectorySourceFile(directory, ['ts', 'md'])
+
+    expect(result).toBe(indexFile)
+  })
+
+  test('handles case-sensitive filenames correctly', () => {
+    const project = new Project({ useInMemoryFileSystem: true })
+    const directory = project.createDirectory('Button')
+    const readmeFile = directory.createSourceFile('readme.md')
+    const result = getDirectorySourceFile(directory, ['md'])
+
+    expect(result).toBe(readmeFile)
+  })
+
+  test('returns undefined for an empty directory', () => {
+    const project = new Project({ useInMemoryFileSystem: true })
+    const directory = project.createDirectory('Button')
+    const result = getDirectorySourceFile(directory, ['ts', 'md'])
+
+    expect(result).toBeUndefined()
+  })
+})

--- a/packages/renoun/src/utils/get-directory-source-file.ts
+++ b/packages/renoun/src/utils/get-directory-source-file.ts
@@ -16,19 +16,42 @@ const indexFileNames = [
   'md',
   'mdx',
 ].map((extension) => `index.${extension}`)
+
 const readmeFileNames = ['md', 'mdx'].flatMap((extension) => [
   `readme.${extension}`,
   `README.${extension}`,
 ])
+
 const directorySourceFileNames = indexFileNames.concat(readmeFileNames)
 
-/** Get the source file of a directory if it exists. */
-export function getDirectorySourceFile(directory: Directory) {
-  let directorySourceFile: SourceFile | undefined
+/**
+ * Attempts to find a source file in a directory that matches one of the following:
+ * - An index/readme file with a valid extension.
+ * - The directory name with a valid extension.
+ */
+export function getDirectorySourceFile(
+  directory: Directory,
+  validExtensions: string[]
+): SourceFile | undefined {
+  const directoryName = directory.getBaseName()
 
-  for (const sourceFileName of directorySourceFileNames) {
-    directorySourceFile = directory.getSourceFile(sourceFileName)
+  // Check for files with the same name as the directory, with valid extensions.
+  for (const extension of validExtensions) {
+    const exactMatchFileName = `${directoryName}.${extension}`
+    const exactMatchFile = directory.getSourceFile(exactMatchFileName)
+    if (exactMatchFile) {
+      return exactMatchFile
+    }
+  }
 
+  // Filter the default index/readme file names by valid extensions.
+  const validFileNames = directorySourceFileNames.filter((fileName) =>
+    validExtensions.some((extension) => fileName.endsWith(`.${extension}`))
+  )
+
+  // Check for index/readme files.
+  for (const sourceFileName of validFileNames) {
+    const directorySourceFile = directory.getSourceFile(sourceFileName)
     if (directorySourceFile) {
       return directorySourceFile
     }

--- a/packages/renoun/src/utils/get-source-files-path-map.ts
+++ b/packages/renoun/src/utils/get-source-files-path-map.ts
@@ -7,7 +7,6 @@ export function getSourceFilesPathMap(
   options?: {
     baseDirectory?: string
     basePath?: string
-    packageName?: string
   }
 ): Map<string, string> {
   const sourcePathMap = new Map<string, string>()
@@ -17,8 +16,7 @@ export function getSourceFilesPathMap(
     const directoryPathname = filePathToPathname(
       directoryPath,
       options?.baseDirectory,
-      options?.basePath,
-      options?.packageName
+      options?.basePath
     )
 
     sourcePathMap.set(directoryPath, directoryPathname)
@@ -26,22 +24,14 @@ export function getSourceFilesPathMap(
     const sourceFiles = directory.getSourceFiles()
 
     for (const sourceFile of sourceFiles) {
-      const sourceFilePath = sourceFile.getFilePath()
-      const pathname = filePathToPathname(
-        sourceFilePath,
+      const filePath = sourceFile.getFilePath()
+      const filePathname = filePathToPathname(
+        filePath,
         options?.baseDirectory,
-        options?.basePath,
-        options?.packageName
+        options?.basePath
       )
 
-      const baseName = sourceFile.getBaseNameWithoutExtension().toLowerCase()
-
-      // TODO: this can be removed once createSource is removed and filePathToPathname can be refactored
-      if (baseName === 'index' || baseName === 'readme') {
-        sourcePathMap.set(sourceFilePath, pathname + '/' + baseName)
-      } else {
-        sourcePathMap.set(sourceFilePath, pathname)
-      }
+      sourcePathMap.set(filePath, filePathname)
     }
 
     for (const subDirectory of directory.getDirectories()) {


### PR DESCRIPTION
Simplifies how `baseDirectory` works for `Collection`. This was from a legacy implementation that was not well thought out and caused confusion and subtle bugs. This change makes it more explicit and easier to understand.

### Breaking Changes

The `baseDirectory` option for `Collection` is now required to be separate from `filePattern`:

```diff
import { Collection } from 'renoun/collections'

const components = new Collection({
--  filePattern: 'src/components/**/*.ts',
++  filePattern: '**/*.ts',
--  baseDirectory: 'components',
++  baseDirectory: 'src/components',
})
```
