### PR TITLE
update valibot documentation reference

### DIFF
--- a/apps/site/guides/05.valibot.mdx
+++ b/apps/site/guides/05.valibot.mdx
@@ -99,4 +99,4 @@ While the example in this guide focused on validating front matter in MDX files,
 
 By using Valibot, you can add reliable schema validation to your collections in renoun. This ensures that your data is always in the expected format, making your application more robust and maintainable.
 
-For more information, refer to the [valibot documentation](https://github.com/valibot/valibot).
+For more information, refer to the [valibot documentation](https://valibot.dev).


### PR DESCRIPTION
# PR Summary
The `https://github.com/valibot/valibot` repo does not exist. Also, I think it's better to point to the actual valibot documentation located at `https://valibot.dev`.