### PR TITLE
refactor getImport to withImport

### DIFF
--- a/.changeset/hip-bats-worry.md
+++ b/.changeset/hip-bats-worry.md
@@ -1,0 +1,18 @@
+---
+'renoun': minor
+---
+
+Moves the `Directory` `getImport` option to `<Directory>.withModule`. This provides stronger types for inferring the `getRuntimeValue` method.
+
+### Breaking Changes
+
+Update the `getImport` option to `withModule`:
+
+```diff
+export const posts = new Directory<{ mdx: PostType }>({
+    path: 'posts',
+    schema: { mdx: { frontmatter: frontmatterSchema.parse } },
+--    getImport: (path) => import(`./posts/${path}`),
+})
+++  .withModule((path) => import(`./posts/${path}`))
+```

--- a/apps/site/app/(home)/QuickSteps.tsx
+++ b/apps/site/app/(home)/QuickSteps.tsx
@@ -23,8 +23,7 @@ import type { MDXContent } from 'renoun/mdx'
 
 const posts = new Directory<{ mdx: { default: MDXContent } }>({
   path: 'posts',
-  getModule: (path) => import(\`./posts/\${path}\`)
-})
+}).withModule((path) => import(\`./posts/\${path}\`))
 
 export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
   const post = await posts.getFile((await params).slug, 'mdx')

--- a/examples/blog/collections.ts
+++ b/examples/blog/collections.ts
@@ -17,10 +17,10 @@ interface PostType {
 export const posts = new Directory<{ mdx: PostType }>({
   path: 'posts',
   schema: { mdx: { frontmatter: frontmatterSchema.parse } },
-  getModule: (path) => import(`./posts/${path}`),
 })
-  .filter((entry) => isFile(entry, 'mdx'))
-  .sort(async (a, b) => {
+  .withModule((path) => import(`./posts/${path}`))
+  .withFilter((entry) => isFile(entry, 'mdx'))
+  .withSort(async (a, b) => {
     const aFrontmatter = await a.getExport('frontmatter').getRuntimeValue()
     const bFrontmatter = await b.getExport('frontmatter').getRuntimeValue()
 

--- a/examples/design-system/collections.ts
+++ b/examples/design-system/collections.ts
@@ -12,5 +12,4 @@ export const ComponentsCollection = new Directory<{
 }>({
   path: 'components',
   basePath: 'components',
-  getModule: (path) => import(`./components/${path}`),
-})
+}).withModule((path) => import(`./components/${path}`))

--- a/packages/renoun/README.md
+++ b/packages/renoun/README.md
@@ -40,8 +40,7 @@ import { Directory } from 'renoun/file-system'
 
 const posts = new Directory({
   path: 'posts',
-  getModule: (path) => import(`@/posts/${path}`),
-})
+}).withModule((path) => import(`posts/${path}`))
 
 export default async function Page({
   params,
@@ -70,8 +69,7 @@ const posts = new Directory<{
   mdx: { default: MDXContent }
 }>({
   path: 'posts',
-  getModule: (path) => import(`@/posts/${path}`),
-})
+}).withModule((path) => import(`posts/${path}`))
 ```
 
 Now when we call `getExport`, we will get better type checking and intellisense.
@@ -89,8 +87,7 @@ const posts = new Directory<{
   }
 }>({
   path: 'posts',
-  getModule: (path) => import(`@/posts/${path}`),
-})
+}).withModule((path) => import(`posts/${path}`))
 
 export default async function Page() {
   const allPosts = await posts.getFiles()


### PR DESCRIPTION
Moves the `Directory` `getImport` option to `<Directory>.withModule`. This provides stronger types for inferring the `getRuntimeValue` method:

```ts
export const posts = new Directory<{ mdx: PostType }>({
    path: 'posts',
    schema: { mdx: { frontmatter: frontmatterSchema.parse } },
})
  .withModule((path) => import(`./posts/${path}`))

const file = posts.getFileOrThrow('hello-world', 'mdx')
const export = file.getExport('default').getRuntimeValue() // Now available only when withModule is provided
```

The previous implementation using the `getModule` option could not be inferred since the first generic slot is used for extension types.