### PR TITLE
refactor schema to withSchema

### DIFF
--- a/.changeset/khaki-donkeys-sit.md
+++ b/.changeset/khaki-donkeys-sit.md
@@ -1,0 +1,17 @@
+---
+'renoun': minor
+---
+
+Moves the `Directory` `schema` option to `<Directory>.withSchema`. This aligns with the recent refactor of the `getImport` option to `<Directory>.withModule`.
+
+### Breaking Changes
+
+Update the `schema` option to `withSchema`:
+
+```diff
+export const posts = new Directory<{ mdx: PostType }>({
+    path: 'posts',
+--    schema: { mdx: { frontmatter: frontmatterSchema.parse } },
+})
+++  .withSchema('mdx', { frontmatter: frontmatterSchema.parse })
+```

--- a/examples/blog/collections.ts
+++ b/examples/blog/collections.ts
@@ -16,8 +16,8 @@ interface PostType {
 
 export const posts = new Directory<{ mdx: PostType }>({
   path: 'posts',
-  schema: { mdx: { frontmatter: frontmatterSchema.parse } },
 })
+  .withSchema('mdx', { frontmatter: frontmatterSchema.parse })
   .withModule((path) => import(`./posts/${path}`))
   .withFilter((entry) => isFile(entry, 'mdx'))
   .withSort(async (a, b) => {

--- a/packages/renoun/src/file-system/index.test.ts
+++ b/packages/renoun/src/file-system/index.test.ts
@@ -370,27 +370,26 @@ describe('file system', () => {
       ts: { metadata: { title: string } }
     }>({
       fileSystem,
-      schema: {
-        ts: {
-          metadata: (value) => {
-            if (typeof value.title === 'string') {
-              return value
-            }
-            throw new Error('Expected a title')
-          },
-        },
-      },
-    }).withModule(async (path) => {
-      const transpiledCode = await fileSystem.transpileFile(path)
-      const module = { exports: {} }
-
-      runInNewContext(
-        `(function(module, exports) { ${transpiledCode} })(module, module.exports);`,
-        { module }
-      )
-
-      return module.exports
     })
+      .withSchema('ts', {
+        metadata: (value) => {
+          if (typeof value.title === 'string') {
+            return value
+          }
+          throw new Error('Expected a title')
+        },
+      })
+      .withModule(async (path) => {
+        const transpiledCode = await fileSystem.transpileFile(path)
+        const module = { exports: {} }
+
+        runInNewContext(
+          `(function(module, exports) { ${transpiledCode} })(module, module.exports);`,
+          { module }
+        )
+
+        return module.exports
+      })
     const file = await directory.getFileOrThrow('index', 'ts')
     const fileExport = file.getExport('metadata')
 
@@ -415,22 +414,21 @@ describe('file system', () => {
       }
     }>({
       fileSystem,
-      schema: {
-        ts: {
-          metadata: metadataSchema.parse,
-        },
-      },
-    }).withModule(async (path) => {
-      const transpiledCode = await fileSystem.transpileFile(path)
-      const module = { exports: {} }
-
-      runInNewContext(
-        `(function(module, exports) { ${transpiledCode} })(module, module.exports);`,
-        { module }
-      )
-
-      return module.exports
     })
+      .withSchema('ts', {
+        metadata: metadataSchema.parse,
+      })
+      .withModule(async (path) => {
+        const transpiledCode = await fileSystem.transpileFile(path)
+        const module = { exports: {} }
+
+        runInNewContext(
+          `(function(module, exports) { ${transpiledCode} })(module, module.exports);`,
+          { module }
+        )
+
+        return module.exports
+      })
     const file = await directory.getFileOrThrow('hello-world', 'ts')
     const metadata = await file.getExport('metadata').getRuntimeValue()
 


### PR DESCRIPTION

Moves the `Directory` `schema` option to `<Directory>.withSchema`. This aligns with the recent refactor of the `getImport` option to `<Directory>.withModule`.

### Breaking Changes

Update the `schema` option to `withSchema`:

```ts
export const posts = new Directory<{ mdx: PostType }>({ path: 'posts' })
  .withSchema('mdx', { frontmatter: frontmatterSchema.parse })
```