### PR TITLE
refactor basePath to withBasePath

### DIFF
--- a/.changeset/lazy-camels-appear.md
+++ b/.changeset/lazy-camels-appear.md
@@ -2,7 +2,7 @@
 'renoun': minor
 ---
 
-Moves the `Directory` `basePath` option to `<Directory>.withBasePath`. This aligns with the other recent refactor of `Directory` options.
+Moves the `Directory` `basePath` option to `<Directory>.withBasePath`. This aligns with the recent refactor of other `Directory` options.
 
 ### Breaking Changes
 

--- a/.changeset/lazy-camels-appear.md
+++ b/.changeset/lazy-camels-appear.md
@@ -1,0 +1,17 @@
+---
+'renoun': minor
+---
+
+Moves the `Directory` `basePath` option to `<Directory>.withBasePath`. This aligns with the other recent refactor of `Directory` options.
+
+### Breaking Changes
+
+Update the `basePath` option to `withBasePath`:
+
+```diff
+export const posts = new Directory<{ mdx: PostType }>({
+    path: 'posts',
+--    basePath: 'blog',
+})
+++  .withBasePath('blog')
+```

--- a/packages/renoun/src/file-system/index.test.ts
+++ b/packages/renoun/src/file-system/index.test.ts
@@ -550,7 +550,7 @@ describe('file system', () => {
   test('generates tree navigation', async () => {
     const projectDirectory = new Directory({
       path: 'fixtures/project',
-    })
+    }).withBasePath('project')
 
     async function buildTreeNavigation<Entry extends FileSystemEntry<any>>(
       entry: Entry
@@ -580,23 +580,23 @@ describe('file system', () => {
           "children": [
             {
               "name": "client",
-              "path": "/rpc/client",
+              "path": "/project/rpc/client",
             },
             {
               "name": "server",
-              "path": "/rpc/server",
+              "path": "/project/rpc/server",
             },
           ],
           "name": "rpc",
-          "path": "/rpc",
+          "path": "/project/rpc",
         },
         {
           "name": "server",
-          "path": "/server",
+          "path": "/project/server",
         },
         {
           "name": "types",
-          "path": "/types",
+          "path": "/project/types",
         },
       ]
     `)

--- a/packages/renoun/src/file-system/index.test.ts
+++ b/packages/renoun/src/file-system/index.test.ts
@@ -396,7 +396,7 @@ describe('file system', () => {
     await expect(
       fileExport!.getRuntimeValue()
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: [renoun] Schema validation failed to parse export "metadata" at file path "./index.ts" errored with: Expected a title]`
+      `[Error: [renoun] Schema validation failed to parse export "metadata" at file path "index.ts" errored with: Expected a title]`
     )
   })
 
@@ -550,7 +550,6 @@ describe('file system', () => {
   test('generates tree navigation', async () => {
     const projectDirectory = new Directory({
       path: 'fixtures/project',
-      basePath: 'project',
     })
 
     async function buildTreeNavigation<Entry extends FileSystemEntry<any>>(
@@ -581,23 +580,23 @@ describe('file system', () => {
           "children": [
             {
               "name": "client",
-              "path": "/project/rpc/client",
+              "path": "/rpc/client",
             },
             {
               "name": "server",
-              "path": "/project/rpc/server",
+              "path": "/rpc/server",
             },
           ],
           "name": "rpc",
-          "path": "/project/rpc",
+          "path": "/rpc",
         },
         {
           "name": "server",
-          "path": "/project/server",
+          "path": "/server",
         },
         {
           "name": "types",
-          "path": "/project/types",
+          "path": "/types",
         },
       ]
     `)
@@ -612,28 +611,24 @@ describe('file system', () => {
     expect(readmeFile?.getName()).toBe('components')
   })
 
-  test('adds basePath to file and directory getPath', async () => {
+  test('adds base path to entry getPath and getPathSegments', async () => {
     const projectDirectory = new Directory({
       path: 'fixtures/project',
-      basePath: 'renoun',
-    })
+    }).withBasePath('renoun')
+
+    expect(projectDirectory.getBasePath()).toBe('renoun')
+
     const file = await projectDirectory.getFileOrThrow('server', 'ts')
-    const directory = await projectDirectory.getDirectoryOrThrow('rpc')
 
     expect(file.getPath()).toBe('/renoun/server')
-    expect(directory.getPath()).toBe('/renoun/rpc')
-  })
+    expect(file.getPathSegments()).toEqual(['renoun', 'server'])
 
-  test('does not add basePath to getPathSegments', async () => {
-    const projectDirectory = new Directory({
-      path: 'fixtures/project',
-      basePath: 'renoun',
-    })
-    const segments = (
-      await projectDirectory.getDirectoryOrThrow('rpc')
-    ).getPathSegments()
+    const directory = await projectDirectory.getDirectoryOrThrow('rpc')
 
-    expect(segments).toEqual(['rpc'])
+    expect(directory.getPath({ includeBasePath: false })).toBe('/rpc')
+    expect(directory.getPathSegments({ includeBasePath: false })).toEqual([
+      'rpc',
+    ])
   })
 
   test('uses file name for anonymous default export metadata', async () => {

--- a/packages/renoun/src/file-system/index.tsx
+++ b/packages/renoun/src/file-system/index.tsx
@@ -573,13 +573,12 @@ export class Directory<
   }
 
   /** Returns a new `Directory` with a base path applied to all descendant entries. */
-  withBasePath(path: string) {
-    const directory = new Directory<Types, true, Entry>({
+  withBasePath(path: string): Directory<Types, HasModule, Entry> {
+    const directory = new Directory<Types, HasModule, Entry>({
       path: this.#path,
       fileSystem: this.#fileSystem,
     })
 
-    directory.setDirectory(this)
     directory.#basePath = path
     directory.#schemas = this.#schemas
     if (this.#getModule) {
@@ -609,7 +608,6 @@ export class Directory<
       fileSystem: this.#fileSystem,
     })
 
-    directory.setDirectory(this)
     directory.setModuleGetter(getModule)
     directory.#basePath = this.#basePath
     directory.#schemas = this.#schemas
@@ -653,7 +651,6 @@ export class Directory<
       fileSystem: this.#fileSystem,
     })
 
-    directory.setDirectory(this)
     directory.setFilterCallback(filter)
     directory.#basePath = this.#basePath
     directory.#schemas = this.#schemas
@@ -686,7 +683,6 @@ export class Directory<
       fileSystem: this.#fileSystem,
     })
 
-    directory.setDirectory(this)
     directory.setSortCallback(sort)
     directory.#basePath = this.#basePath
     directory.#schemas = this.#schemas
@@ -724,7 +720,6 @@ export class Directory<
       fileSystem: this.#fileSystem,
     })
 
-    directory.setDirectory(this)
     directory.setSchema(extension, schema)
     directory.#basePath = this.#basePath
     if (this.#getModule) {
@@ -982,6 +977,7 @@ export class Directory<
           entryGroup: this.#entryGroup,
         })
 
+        directory.#basePath = this.#basePath
         directory.#schemas = this.#schemas
 
         if (this.#getModule) {


### PR DESCRIPTION
Moves the `Directory` `basePath` option to `<Directory>.withBasePath`. This aligns with the recent refactor of other `Directory` options.

### Breaking Changes

Update the `basePath` option to `withBasePath`:

```ts
export const posts = new Directory<{ mdx: PostType }>({
    path: 'posts',
})
  .withBasePath('blog')
```