### PR TITLE
add default mdx loader

### DIFF
--- a/.changeset/few-swans-call.md
+++ b/.changeset/few-swans-call.md
@@ -1,0 +1,23 @@
+---
+'renoun': minor
+---
+
+Adds a default `mdx` loader to `JavaScriptFile` that uses the `MDXRenderer` component. This allows MDX files without imports to be rendered easily:
+
+```tsx
+import { Directory } from 'renoun/file-system'
+
+const posts = new Directory({ path: 'posts' })
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const slug = (await params).slug
+  const post = await posts.getFileOrThrow(slug, 'mdx')
+  const Content = await post.getExportValueOrThrow('default')
+
+  return <Content />
+}
+```

--- a/apps/site/app/(home)/QuickSteps.tsx
+++ b/apps/site/app/(home)/QuickSteps.tsx
@@ -17,12 +17,7 @@ const posts = new Directory({ path: 'posts' })`,
     content: `Query and render your file system entries programmatically using a simple API.`,
     code: `import { Directory } from 'renoun/file-system'
 
-const posts = new Directory({
-  path: 'posts',
-  loaders: {
-    mdx: (path) => import(\`@/posts/\${path}.mdx\`),
-  }
-})
+const posts = new Directory({ path: 'posts'})
 
 export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
   const slug = (await params).slug
@@ -37,7 +32,7 @@ export default async function Page({ params }: { params: Promise<{ slug: string 
   return <Content />
 }`,
     codeBlockProps: {
-      focusedLines: '5-7,10-30',
+      focusedLines: '4-20',
     },
   },
   {

--- a/apps/site/components/SiblingLink.tsx
+++ b/apps/site/components/SiblingLink.tsx
@@ -133,7 +133,7 @@ async function resolveEntryMetadata(entry: FileSystemEntry) {
       const readmeFile = await entry.getFile('readme', 'mdx')
 
       if (readmeFile) {
-        file = readmeFile
+        file = readmeFile as unknown as JavaScriptFile<Metadata>
       } else {
         return
       }

--- a/packages/renoun/src/file-system/index.test.ts
+++ b/packages/renoun/src/file-system/index.test.ts
@@ -21,18 +21,7 @@ import {
   isJavaScriptFile,
   withSchema,
 } from './index'
-
-type Expect<Type extends true> = Type
-
-type Not<_ extends false> = true
-
-type IsNot<Type, Expected> = Type extends Expected ? false : true
-
-type IsAny<Type> = 0 extends 1 & Type ? true : false
-
-type IsNotAny<Type> = true extends IsAny<Type> ? false : true
-
-type IsNever<Type> = Type extends never ? true : false
+import type { Expect, Is, IsNotAny } from './types'
 
 describe('file system', () => {
   describe('File', () => {
@@ -91,6 +80,16 @@ describe('file system', () => {
     const entries = await fileSystem.readDirectory('fixtures/utils')
     expect(entries).toHaveLength(1)
     expect(entries[0].name).toBe('path.ts')
+  })
+
+  test('directory with no configuration', async () => {
+    const directory = new Directory()
+    const file = await directory.getFileOrThrow('fixtures/docs/index', 'mdx')
+    const Content = await file.getExportValueOrThrow('default')
+
+    type Tests = [Expect<Is<typeof Content, MDXContent>>]
+
+    expectTypeOf(Content).toMatchTypeOf<MDXContent>()
   })
 
   test('directory with virtual file system', async () => {

--- a/packages/renoun/src/file-system/index.tsx
+++ b/packages/renoun/src/file-system/index.tsx
@@ -199,7 +199,7 @@ type WithDefaultTypes<Types> = DefaultModuleTypes & Types
 type InferDefaultModuleTypes<Extension extends string> =
   Extension extends keyof DefaultModuleTypes
     ? DefaultModuleTypes[Extension]
-    : Record<string, unknown>
+    : ModuleExports
 
 /** Infer extension types for all loaders in a module. */
 export type InferModuleLoadersTypes<Loaders extends ModuleLoaders> = {

--- a/packages/renoun/src/file-system/types.ts
+++ b/packages/renoun/src/file-system/types.ts
@@ -1,3 +1,17 @@
+export type Expect<Type extends true> = Type
+
+export type Not<_ extends false> = true
+
+export type Is<Type, Expected> = Type extends Expected ? true : false
+
+export type IsNot<Type, Expected> = Type extends Expected ? false : true
+
+export type IsAny<Type> = 0 extends 1 & Type ? true : false
+
+export type IsNotAny<Type> = true extends IsAny<Type> ? false : true
+
+export type IsNever<Type> = Type extends never ? true : false
+
 export type DirectoryEntry = {
   name: string
   path: string
@@ -5,6 +19,33 @@ export type DirectoryEntry = {
   isFile: boolean
 }
 
+/** Get the last segment of a path. */
+type LastSegment<Path extends string> = Path extends `${infer _}/${infer Rest}`
+  ? LastSegment<Rest>
+  : Path
+
+/**
+ * Tests if a string leads with a number followed by a single dot.
+ *
+ * - `"01.introduction"` => `true` (numeric prefix + single dot)
+ * - `"02.configuration.mdx"` => `false` (numeric prefix + 2 dots)
+ * - `"myfile.txt"` => `false` (not purely a numeric prefix)
+ */
+type IsSingleDotNumericPrefix<Segment extends string> =
+  Segment extends `${infer Digits}.${infer Rest}`
+    ? Digits extends `${number}`
+      ? // If `Rest` itself has another dot, then it's multiple dots => `false`
+        Rest extends `${string}.${string}`
+        ? false
+        : true
+      : false
+    : false
+
+/** Get the last part of a string after the final dot. */
+type LastPartAfterDot<Segment extends string> =
+  Segment extends `${string}.${infer Tail}` ? LastPartAfterDot<Tail> : Segment
+
+/** Split a string by a delimiter. */
 type SplitBy<
   Pattern extends string,
   Delimiter extends string,
@@ -12,23 +53,27 @@ type SplitBy<
   ? Head | SplitBy<Tail, Delimiter>
   : Pattern
 
+/** Parse the extension from a string. */
 type ParseExtension<Extension extends string> =
-  Extension extends `{${infer NestedExtension}}`
-    ? SplitBy<NestedExtension, ','>
-    : Extension extends `@(${infer NestedExtension})`
-      ? SplitBy<NestedExtension, '|'>
-      : Extension
+  Extension extends `{${infer Nested}}`
+    ? SplitBy<LastPartAfterDot<Nested>, ','>
+    : Extension extends `@(${infer Nested})`
+      ? SplitBy<LastPartAfterDot<Nested>, '|'>
+      : LastPartAfterDot<Extension>
 
-export type ExtractFilePatternExtension<Pattern extends string> =
-  Pattern extends `${string}/**/*.${infer Extension}`
-    ? ParseExtension<Extension>
-    : Pattern extends `**/*.${infer Extension}`
+/** Extract the file extension from a path. */
+export type ExtractFileExtension<Path extends string> =
+  IsSingleDotNumericPrefix<LastSegment<Path>> extends true
+    ? string
+    : LastSegment<Path> extends `${string}.${infer Extension}`
       ? ParseExtension<Extension>
-      : Pattern extends `*.${infer Extension}`
-        ? ParseExtension<Extension>
-        : Pattern extends `${string}.${infer Extension}`
-          ? ParseExtension<Extension>
-          : never
+      : LastSegment<Path> extends `**/*.${infer Ext}`
+        ? ParseExtension<Ext>
+        : LastSegment<Path> extends `${string}/**/*.${infer Ext}`
+          ? ParseExtension<Ext>
+          : LastSegment<Path> extends `*.${infer Ext}`
+            ? ParseExtension<Ext>
+            : string
 
 export type IsRecursiveFilePattern<Pattern extends string> =
   Pattern extends `**/${string}`
@@ -38,3 +83,18 @@ export type IsRecursiveFilePattern<Pattern extends string> =
       : Pattern extends `${string}/**`
         ? true
         : false
+
+type Tests = [
+  Expect<Is<ExtractFileExtension<'index.ts'>, 'ts'>>,
+  Expect<Is<ExtractFileExtension<'**/*.ts'>, 'ts'>>,
+  Expect<Is<ExtractFileExtension<'*.tsx'>, 'tsx'>>,
+  Expect<Is<ExtractFileExtension<'src/**/*.js'>, 'js'>>,
+  Expect<Is<ExtractFileExtension<'src/**/index.ts'>, 'ts'>>,
+  Expect<Is<ExtractFileExtension<'src/index.ts'>, 'ts'>>,
+  Expect<Is<ExtractFileExtension<'src/index'>, string>>,
+  Expect<Is<ExtractFileExtension<'/components/Button.test.tsx'>, 'tsx'>>,
+  Expect<Is<ExtractFileExtension<'01.introduction'>, string>>,
+  Expect<Is<ExtractFileExtension<'docs/01.introduction'>, string>>,
+  Expect<Is<ExtractFileExtension<'docs/02.configuration.mdx'>, 'mdx'>>,
+  Expect<Is<ExtractFileExtension<'src/index.{ts,tsx}'>, 'ts' | 'tsx'>>,
+]


### PR DESCRIPTION
Adds a default `mdx` loader to `JavaScriptFile` that uses the `MDXRenderer` component. This allows MDX files without imports to be rendered easily:

```tsx
import { Directory } from 'renoun/file-system'

const posts = new Directory({ path: 'posts' })

export default async function Page({
  params,
}: {
  params: Promise<{ slug: string }>
}) {
  const slug = (await params).slug
  const post = await posts.getFileOrThrow(slug, 'mdx')
  const Content = await post.getExportValueOrThrow('default')

  return <Content />
}
```