### PR TITLE
remove file system throw methods

### DIFF
--- a/.changeset/fair-candles-grin.md
+++ b/.changeset/fair-candles-grin.md
@@ -13,7 +13,7 @@ import { Directory } from 'renoun/file-system'
 
 const posts = new Directory({ path: 'posts' })
 
-posts.getFile('slug', 'mdxOrThrow').catch((error) => {
+posts.getFile('hello-world', 'mdx').catch((error) => {
   if (error instanceof FileNotFoundError) {
     return undefined
   }

--- a/.changeset/fair-candles-grin.md
+++ b/.changeset/fair-candles-grin.md
@@ -1,0 +1,22 @@
+---
+'renoun': major
+---
+
+Removes all `*OrThrow` methods from `Directory` and `EntryGroup`. This also exports two new custom errors, `FileNotFoundError` and `FileExportNotFoundError` to handle missing files and exports.
+
+### Breaking Changes
+
+`Directory` and `EntryGroup` no longer have `*OrThrow` methods, use the respective methods instead. To get the same functionality as before, you can catch the error and handle it accordingly:
+
+```ts
+import { Directory } from 'renoun/file-system'
+
+const posts = new Directory({ path: 'posts' })
+
+posts.getFile('slug', 'mdxOrThrow').catch((error) => {
+  if (error instanceof FileNotFoundError) {
+    return undefined
+  }
+  throw error
+})
+```

--- a/.changeset/few-swans-call.md
+++ b/.changeset/few-swans-call.md
@@ -15,8 +15,8 @@ export default async function Page({
   params: Promise<{ slug: string }>
 }) {
   const slug = (await params).slug
-  const post = await posts.getFileOrThrow(slug, 'mdx')
-  const Content = await post.getExportValueOrThrow('default')
+  const post = await posts.getFile(slug, 'mdx')
+  const Content = await post.getExportValue('default')
 
   return <Content />
 }

--- a/apps/site/app/(home)/QuickSteps.tsx
+++ b/apps/site/app/(home)/QuickSteps.tsx
@@ -27,7 +27,7 @@ export default async function Page({ params }: { params: Promise<{ slug: string 
     return <div>Post not found</div>
   }
 
-  const Content = await post.getExportValueOrThrow('default')
+  const Content = await post.getExportValue('default')
     
   return <Content />
 }`,

--- a/apps/site/app/(site)/docs/[...slug]/page.tsx
+++ b/apps/site/app/(site)/docs/[...slug]/page.tsx
@@ -15,7 +15,7 @@ export default async function Doc({
   params: Promise<{ slug: string[] }>
 }) {
   const { slug } = await params
-  const file = await DocsCollection.getFileOrThrow(slug, 'mdx')
+  const file = await DocsCollection.getFile(slug, 'mdx')
 
   return <DocumentEntry file={file} entryGroup={CollectionGroup} />
 }

--- a/apps/site/app/(site)/guides/[...slug]/page.tsx
+++ b/apps/site/app/(site)/guides/[...slug]/page.tsx
@@ -15,7 +15,7 @@ export default async function Guide({
   params: Promise<{ slug: string[] }>
 }) {
   const { slug } = await params
-  const file = await GuidesCollection.getFileOrThrow(slug, 'mdx')
+  const file = await GuidesCollection.getFile(slug, 'mdx')
 
   return <DocumentEntry file={file} entryGroup={CollectionGroup} />
 }

--- a/apps/site/app/(site)/guides/page.tsx
+++ b/apps/site/app/(site)/guides/page.tsx
@@ -2,7 +2,7 @@ import { GuidesCollection } from '@/collections'
 import { DocumentEntry } from '@/components/DocumentEntry'
 
 export default async function Guides() {
-  const file = await GuidesCollection.getFileOrThrow('index', 'mdx')
+  const file = await GuidesCollection.getFile('index', 'mdx')
 
   return (
     <DocumentEntry

--- a/apps/site/app/(site)/utilities/file-system/page.tsx
+++ b/apps/site/app/(site)/utilities/file-system/page.tsx
@@ -4,7 +4,7 @@ import { FileSystemCollection } from '@/collections'
 import { TableOfContents } from '@/components/TableOfContents'
 
 export default async function Page() {
-  const sourceFile = await FileSystemCollection.getFileOrThrow('index', 'tsx')
+  const sourceFile = await FileSystemCollection.getFile('index', 'tsx')
 
   if (!sourceFile) {
     return null
@@ -16,8 +16,8 @@ export default async function Page() {
     return null
   }
 
-  const Content = await docFile.getExportValueOrThrow('default')
-  const headings = await docFile.getExportValueOrThrow('headings')
+  const Content = await docFile.getExportValue('default')
+  const headings = await docFile.getExportValue('headings')
   const fileExports = await sourceFile.getExports()
 
   return (

--- a/apps/site/components/DocumentEntry.tsx
+++ b/apps/site/components/DocumentEntry.tsx
@@ -22,9 +22,9 @@ export async function DocumentEntry({
   shouldRenderTableOfContents?: boolean
   shouldRenderUpdatedAt?: boolean
 }) {
-  const Content = await file.getExportValueOrThrow('default')
-  const metadata = await file.getExportValueOrThrow('metadata')
-  const headings = await file.getExportValueOrThrow('headings')
+  const Content = await file.getExportValue('default')
+  const metadata = await file.getExportValue('metadata')
+  const headings = await file.getExportValue('headings')
   const updatedAt = shouldRenderUpdatedAt
     ? await file.getLastCommitDate()
     : null

--- a/apps/site/components/Sidebar/TreeNavigation.tsx
+++ b/apps/site/components/Sidebar/TreeNavigation.tsx
@@ -1,4 +1,5 @@
 import {
+  FileExportNotFoundError,
   isFile,
   isJavaScriptFile,
   type Directory,
@@ -19,7 +20,12 @@ async function ListNavigation({
   const depth = entry.getDepth()
   const metadata =
     variant === 'title' && isJavaScriptFile(entry)
-      ? await entry.getExportValueOrThrow('metadata')
+      ? await entry.getExportValue('metadata').catch((error) => {
+          if (error instanceof FileExportNotFoundError) {
+            return undefined
+          }
+          throw error
+        })
       : null
 
   if (isFile(entry)) {

--- a/apps/site/docs/02.getting-started.mdx
+++ b/apps/site/docs/02.getting-started.mdx
@@ -104,12 +104,7 @@ export default async function Page({
 }) {
   const slug = (await params).slug
   const post = await posts.getFile(slug, 'mdx')
-
-  if (!post) {
-    return <div>Post not found</div>
-  }
-
-  const Content = await post.getExportValueOrThrow('default')
+  const Content = await post.getExportValue('default')
 
   return <Content />
 }

--- a/apps/site/guides/02.next.mdx
+++ b/apps/site/guides/02.next.mdx
@@ -156,12 +156,7 @@ export default async function Page({
 }) {
   const slug = (await params).slug
   const post = await posts.getFile(slug, 'mdx')
-
-  if (!post) {
-    return <div>Post not found</div>
-  }
-
-  const Content = await post.getExportValueOrThrow('default')
+  const Content = await post.getExportValue('default')
 
   return <Content />
 }

--- a/apps/site/guides/AllGuides.tsx
+++ b/apps/site/guides/AllGuides.tsx
@@ -5,7 +5,7 @@ export async function AllGuides() {
   const entries = await GuidesCollection.getEntries()
 
   return entries.map(async (entry, index) => {
-    const metadata = await entry.getExportValueOrThrow('metadata')
+    const metadata = await entry.getExportValue('metadata')
 
     return (
       <Card

--- a/examples/blog/app/[slug]/page.tsx
+++ b/examples/blog/app/[slug]/page.tsx
@@ -10,15 +10,15 @@ export default async function Page({
 }: {
   params: Promise<{ slug: string }>
 }) {
-  const post = await posts.getFileOrThrow((await params).slug, 'mdx')
-  const frontmatter = await post.getExportValueOrThrow('frontmatter')
+  const post = await posts.getFile((await params).slug, 'mdx')
+  const frontmatter = await post.getExportValue('frontmatter')
   const formattedDate = new Intl.DateTimeFormat('en-US', {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
     timeZone: 'UTC',
   }).format(frontmatter.date)
-  const Content = await post.getExportValueOrThrow('default')
+  const Content = await post.getExportValue('default')
 
   return (
     <>

--- a/examples/blog/app/page.tsx
+++ b/examples/blog/app/page.tsx
@@ -10,7 +10,7 @@ export default async function Page() {
       <ul>
         {allPosts.map(async (post) => {
           const path = post.getPath()
-          const frontmatter = await post.getExportValueOrThrow('frontmatter')
+          const frontmatter = await post.getExportValue('frontmatter')
 
           return (
             <li key={path}>

--- a/examples/blog/collections.ts
+++ b/examples/blog/collections.ts
@@ -18,8 +18,8 @@ export const posts = new Directory({
     ),
   },
   sort: async (a, b) => {
-    const aFrontmatter = await a.getExportValueOrThrow('frontmatter')
-    const bFrontmatter = await b.getExportValueOrThrow('frontmatter')
+    const aFrontmatter = await a.getExportValue('frontmatter')
+    const bFrontmatter = await b.getExportValue('frontmatter')
 
     return bFrontmatter.date.getTime() - aFrontmatter.date.getTime()
   },

--- a/packages/renoun/README.md
+++ b/packages/renoun/README.md
@@ -177,8 +177,8 @@ const posts = new Directory({
 Now when calling `JavaScript#getExportValue` and `JavaScriptExport#getRuntimeValue` we get stronger type-checking and autocompletion:
 
 ```tsx
-const file = await posts.getFileOrThrow('hello-world', 'mdx')
-const frontmatter = await file.getExportValueOrThrow('frontmatter')
+const file = await posts.getFile('hello-world', 'mdx')
+const frontmatter = await file.getExportValue('frontmatter')
 
 frontmatter.title // string
 frontmatter.date // Date

--- a/packages/renoun/src/file-system/README.mdx
+++ b/packages/renoun/src/file-system/README.mdx
@@ -41,7 +41,7 @@ export default async function Page({
     return <div>Post not found</div>
   }
 
-  const Content = await post.getExportValueOrThrow('default')
+  const Content = await post.getExportValue('default')
 
   return <Content />
 }
@@ -76,7 +76,7 @@ export default async function Page() {
       <ul>
         {allPosts.map(async (post) => {
           const path = post.getPath()
-          const frontmatter = await post.getExportValueOrThrow('frontmatter')
+          const frontmatter = await post.getExportValue('frontmatter')
 
           return (
             <li key={path}>

--- a/packages/renoun/src/project/get-project.ts
+++ b/packages/renoun/src/project/get-project.ts
@@ -111,13 +111,13 @@ export function getProject(options?: ProjectOptions) {
 
               activeRefreshingProjects.add(promise)
             } else {
-              // project.addSourceFileAtPath(filePath)
+              project.addSourceFileAtPath(filePath)
             }
           }
         } catch (error) {
           if (error instanceof Error) {
             throw new Error(
-              `[renoun] An error occurred while trying to ${eventType} the file path at: ${filename}`,
+              `[renoun] An error occurred while trying to update the project based on a change to the file system for: ${filename}`,
               { cause: error }
             )
           }

--- a/packages/renoun/src/project/get-project.ts
+++ b/packages/renoun/src/project/get-project.ts
@@ -111,13 +111,13 @@ export function getProject(options?: ProjectOptions) {
 
               activeRefreshingProjects.add(promise)
             } else {
-              project.addSourceFileAtPath(filePath)
+              // project.addSourceFileAtPath(filePath)
             }
           }
         } catch (error) {
           if (error instanceof Error) {
             throw new Error(
-              `[renoun] An error occurred while trying to update the project based on a change to the file system for: ${filename}`,
+              `[renoun] An error occurred while trying to ${eventType} the file path at: ${filename}`,
               { cause: error }
             )
           }


### PR DESCRIPTION
Removes all `*OrThrow` methods from `Directory` and `EntryGroup` which aligns the API better with how `node:fs` works. The throw methods were originally borrowed from `ts-morph`, however this wasn't fully consistent with the other methods and made maintenance more cumbersome.

This additionally exports two new custom errors, `FileNotFoundError` and `FileExportNotFoundError` to help with catching and handling missing files and exports.

### Breaking Changes

`Directory` and `EntryGroup` no longer have `*OrThrow` methods, use the respective methods instead. To get the same functionality as before, you can catch the error and handle it accordingly:

```ts
import { Directory } from 'renoun/file-system'

const posts = new Directory({ path: 'posts' })

posts.getFile('hello-world', 'mdx').catch((error) => {
  if (error instanceof FileNotFoundError) {
    return undefined
  }
  throw error
})
```
