### PR TITLE
fix running multiple servers

### DIFF
--- a/.changeset/wise-eggs-boil.md
+++ b/.changeset/wise-eggs-boil.md
@@ -1,0 +1,13 @@
+---
+'renoun': minor
+---
+
+Fixes running multiple renoun WebSocket servers by setting the port to `0` by default. This allows the OS to assign an available port.
+
+This also adds a new `startServer` function that will only ever start the WebSocket server once per process. This is useful in frameworks like Next.js where the configuration is not shared across multiple instances.
+
+```ts
+import { startServer } from 'renoun/server'
+
+await startServer()
+```

--- a/apps/site/guides/02.next.mdx
+++ b/apps/site/guides/02.next.mdx
@@ -49,27 +49,25 @@ and utilities in your project to provide accurate and performant code analysis a
 
 ### Custom Server
 
-Alternatively, if you would like fine-grained control over the renoun WebSocket server, you can create the server manually in your project's `next.config` file:
+Alternatively, if you don't want to use the CLI, the renoun WebSocket server can be started in your project's `next.config` file using the `startServer` utility:
 
 ```js filename="01.next.config.mjs"
-import { createServer } from 'renoun/server'
+import type { NextConfig } from "next";
+import { startServer } from 'renoun/server'
 
-if (process.env.RENOUN_SERVER_STARTED !== 'true') {
-  createServer()
-  process.env.RENOUN_SERVER_STARTED = 'true'
-}
+await startServer()
 
-export default {
-  // ...
-}
+const nextConfig: NextConfig = {
+  /* config options here */
+};
+
+export default nextConfig;
 ```
 
-Using a flag ensures that the server is only started once during the build and development process.
-
 <Note>
-  This does not currently work with a TypeScript Next.js configuration file
-  (`next.config.ts`) due to ESM issues. Please use the CLI above or a JavaScript
-  configuration file.
+  The `startServer` function does not currently work with a TypeScript Next.js
+  configuration file (`next.config.ts`) due to ESM issues. Please use the CLI
+  above or a JavaScript configuration file instead.
 </Note>
 
 ### Webpack Configuration

--- a/apps/site/guides/02.next.mdx
+++ b/apps/site/guides/02.next.mdx
@@ -52,16 +52,13 @@ and utilities in your project to provide accurate and performant code analysis a
 Alternatively, if you don't want to use the CLI, the renoun WebSocket server can be started in your project's `next.config` file using the `startServer` utility:
 
 ```js filename="01.next.config.mjs"
-import type { NextConfig } from "next";
 import { startServer } from 'renoun/server'
 
 await startServer()
 
-const nextConfig: NextConfig = {
+export default {
   /* config options here */
-};
-
-export default nextConfig;
+}
 ```
 
 <Note>

--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -1,6 +1,6 @@
 import createMDXPlugin from '@next/mdx'
 import { remarkPlugins, rehypePlugins } from 'renoun/mdx'
-import { createServer } from 'renoun/server'
+import { startServer } from 'renoun/server'
 
 const withMDX = createMDXPlugin({
   extension: /\.mdx?$/,
@@ -11,10 +11,7 @@ const withMDX = createMDXPlugin({
   },
 })
 
-if (process.env.RENOUN_SERVER_STARTED !== 'true') {
-  createServer()
-  process.env.RENOUN_SERVER_STARTED = 'true'
-}
+await startServer()
 
 export default withMDX({
   output: 'export',

--- a/packages/renoun/src/cli/index.ts
+++ b/packages/renoun/src/cli/index.ts
@@ -30,10 +30,16 @@ if (firstArgument === 'next' || firstArgument === 'waku') {
     process.env.NODE_ENV = isDev ? 'development' : 'production'
   }
 
-  function runSubProcess() {
+  async function runSubProcess() {
+    const port = String(await server.getPort())
+
     subProcess = spawn(firstArgument, [secondArgument, ...restArguments], {
       stdio: 'inherit',
       shell: true,
+      env: {
+        ...process.env,
+        RENOUN_SERVER_PORT: port,
+      },
     })
 
     subProcess.on('close', (code: number) => {
@@ -42,9 +48,9 @@ if (firstArgument === 'next' || firstArgument === 'waku') {
     })
   }
 
-  const server = createServer()
+  const server = await createServer()
 
-  runSubProcess()
+  await runSubProcess()
 
   // Handle Ctrl+C
   process.on('SIGINT', () => cleanupAndExit(0))

--- a/packages/renoun/src/file-system/Refresh.tsx
+++ b/packages/renoun/src/file-system/Refresh.tsx
@@ -7,9 +7,9 @@ let startedWatching = false
  * Refreshes the Next.js development server when a source file changes.
  * @internal
  */
-export function Refresh() {
+export function Refresh({ port }: { port: string }) {
   if (!startedWatching && typeof window !== 'undefined') {
-    new WebSocket(`ws://localhost:5996`).addEventListener(
+    new WebSocket(`ws://localhost:${port}`).addEventListener(
       'message',
       (event: MessageEvent) => {
         const message = JSON.parse(event.data) as WebSocketNotification

--- a/packages/renoun/src/file-system/index.tsx
+++ b/packages/renoun/src/file-system/index.tsx
@@ -762,10 +762,15 @@ export class JavaScriptFileExport<Value> {
         const Component = exportValue as React.ComponentType
         const WrappedComponent = async (props: Record<string, unknown>) => {
           const { Refresh } = await import('./Refresh.js')
+          const port = process.env.RENOUN_SERVER_PORT
+
+          if (port === undefined) {
+            return <Component {...props} />
+          }
 
           return (
             <>
-              <Refresh />
+              <Refresh port={port} />
               <Component {...props} />
             </>
           )

--- a/packages/renoun/src/project/rpc/client.ts
+++ b/packages/renoun/src/project/rpc/client.ts
@@ -27,7 +27,9 @@ export class WebSocketClient {
 
   #connect() {
     import('ws').then(({ default: WebSocket }) => {
-      this.#ws = new WebSocket(`ws://localhost:5996`)
+      this.#ws = new WebSocket(
+        `ws://localhost:${process.env.RENOUN_SERVER_PORT}`
+      )
       this.#ws.addEventListener('open', this.#handleOpenEvent)
       this.#ws.addEventListener('message', this.#handleMessageEvent)
       this.#ws.addEventListener('error', this.#handleErrorEvent)

--- a/packages/renoun/src/project/server.ts
+++ b/packages/renoun/src/project/server.ts
@@ -32,10 +32,11 @@ if (currentHighlighter === null) {
  * Create a WebSocket server that improves the performance of renoun components and
  * utilities by processing type analysis and syntax highlighting in a separate process.
  */
-export function createServer(options?: { port?: number }) {
+export async function createServer(options?: { port?: number }) {
   const server = new WebSocketServer({ port: options?.port })
+  const port = await server.getPort()
 
-  process.env.RENOUN_SERVER = 'true'
+  process.env.RENOUN_SERVER_PORT = String(port)
 
   if (process.env.NODE_ENV === 'development') {
     const rootDirectory = getRootDirectory()
@@ -184,4 +185,14 @@ export function createServer(options?: { port?: number }) {
   )
 
   return server
+}
+
+/**
+ * Starts the WebSocket server for renoun and ensures that it is only ever started
+ * once for the current process. For more control over the server, use `createServer`.
+ */
+export async function startServer(options?: { port?: number }) {
+  if (process.env.RENOUN_SERVER_PORT === undefined) {
+    await createServer(options)
+  }
 }


### PR DESCRIPTION
Fixes running multiple renoun WebSocket servers by setting the port to `0` by default. This allows the OS to assign an available port.

This also adds a new `startServer` function that will only ever start the WebSocket server once per process. This is useful in frameworks like Next.js where the configuration is not shared across multiple instances.

```ts
import { startServer } from 'renoun/server'

await startServer()
```

closes #178