### PR TITLE
fix CodeBlock fallback layout shift

### DIFF
--- a/.changeset/fast-mayflies-clap.md
+++ b/.changeset/fast-mayflies-clap.md
@@ -1,0 +1,5 @@
+---
+'renoun': patch
+---
+
+Fixes `CodeBlock` fallback layout shift during development.


### PR DESCRIPTION
This fixes the `CodeBlock` fallback so it uses the exact same styles to prevent layout shift. This is only run during development while communicating with the WebSocket to calculate syntax highlighting and quick info, but makes for a nicer experience overall.

https://github.com/user-attachments/assets/5e936a89-bd65-4962-b384-883e6bd465e6

