### PR TITLE
allow overriding APIReference rendering

### DIFF
--- a/packages/renoun/src/components/APIReference.tsx
+++ b/packages/renoun/src/components/APIReference.tsx
@@ -1,59 +1,67 @@
-/** @jsxImportSource restyle */
-/** @jsxRuntime automatic */
-import { Fragment, Suspense } from 'react'
-import type { CSSObject } from 'restyle'
+import React, { Fragment, Suspense } from 'react'
 import { resolve } from 'node:path'
-
+import {
+  CodeInline,
+  MDXRenderer,
+  type CodeInlineProps,
+} from '../components/index.js'
 import {
   JavaScriptFile,
   type JavaScriptFileExport,
 } from '../file-system/index.js'
-import { createSlug } from '../utils/create-slug.js'
-import type {
-  AllTypes,
-  ResolvedType,
-  SymbolFilter,
-  TypeOfKind,
+import {
+  isParameterType,
+  isPropertyType,
+  type ClassAccessorType,
+  type ClassMethodType,
+  type FunctionSignatureType,
+  type ResolvedType,
+  type SymbolFilter,
 } from '../utils/resolve-type.js'
-import { isParameterType, isPropertyType } from '../utils/resolve-type.js'
-import { CodeBlock, parsePreProps } from './CodeBlock/index.js'
-import { CodeInline } from './CodeInline.js'
-import { MDXRenderer } from './MDXRenderer.js'
-import type { MDXComponents } from '../mdx/index.js'
+import { createContext, getContext } from '../utils/context.js'
+import { createSlug } from '../utils/create-slug.js'
 
-const mdxComponents = {
-  pre: (props) => {
-    return <CodeBlock {...parsePreProps(props)} />
-  },
-  code: (props) => {
-    return <CodeInline value={props.children} language="typescript" />
-  },
-  p: (props) => <p {...props} css={{ margin: 0 }} />,
-} satisfies MDXComponents
-
-interface SourceString {
-  /** The file path to the source code. */
-  source: string
-
-  /** The working directory to resolve the file path from. Will use the base URL if a URL is provided. */
-  workingDirectory?: string
+export interface APIReferenceComponents {
+  CodeInline: React.ComponentType<CodeInlineProps>
+  MDXRenderer: React.ComponentType<React.ComponentProps<typeof MDXRenderer>>
 }
 
-interface SourceExport {
-  /** The export source from a collection export source to get types from. */
-  source: JavaScriptFile<any> | JavaScriptFileExport<any>
+const APIReferenceConfigContext = createContext<APIReferenceComponents>({
+  CodeInline: CodeInline,
+  MDXRenderer: MDXRenderer,
+})
+
+function useAPIReferenceConfig() {
+  return getContext(APIReferenceConfigContext)
 }
 
-interface Filter {
-  /** A filter to apply to the exported types. */
+const APIReferenceDataContext = createContext<
+  ResolvedType | ResolvedType[] | undefined
+>(undefined)
+
+function useAPIReferenceData() {
+  return getContext(APIReferenceDataContext)
+}
+
+export interface APIReferenceProps {
+  /** The source of the API reference data. */
+  source: string | JavaScriptFile<any> | JavaScriptFileExport<any>
+
+  /** Optional filter for symbols. */
   filter?: SymbolFilter
+
+  /** Optional working directory for relative source paths. */
+  workingDirectory?: string
+
+  /**
+   * Override default components.
+   * e.g. { MDXRenderer: ({ value }) => <MDXRenderer value={value} /> }
+   */
+  components?: Partial<APIReferenceComponents>
+
+  children?: React.ReactNode
 }
 
-export type APIReferenceProps =
-  | (SourceString & Filter)
-  | (SourceExport & Filter)
-
-/** Displays type documentation for all types exported from a file path, `JavaScriptFile`, or `JavaScriptFileExport`. */
 export function APIReference(props: APIReferenceProps) {
   return (
     <Suspense fallback="Loading API references...">
@@ -65,149 +73,141 @@ export function APIReference(props: APIReferenceProps) {
 async function APIReferenceAsync({
   source,
   filter,
-  ...props
+  workingDirectory,
+  components,
+  children,
+}: APIReferenceProps) {
+  const data = await resolveSourceTypeData({
+    source,
+    filter,
+    workingDirectory,
+  })
+  const mergedComponents: APIReferenceComponents = {
+    MDXRenderer: components?.MDXRenderer || MDXRenderer,
+    CodeInline: components?.CodeInline || CodeInline,
+  }
+
+  if (!data) {
+    return null
+  }
+
+  if (Array.isArray(data)) {
+    return (
+      <APIReferenceConfigContext value={mergedComponents}>
+        {data.map((type, index) => (
+          <TypeProvider key={index} type={type}>
+            {children}
+          </TypeProvider>
+        ))}
+      </APIReferenceConfigContext>
+    )
+  }
+
+  return (
+    <APIReferenceConfigContext value={mergedComponents}>
+      <TypeProvider type={data}>{children}</TypeProvider>
+    </APIReferenceConfigContext>
+  )
+}
+
+async function resolveSourceTypeData({
+  source,
+  filter,
+  workingDirectory,
 }: APIReferenceProps) {
   if (typeof source === 'string') {
-    let workingDirectory: string | undefined
-
-    if ('workingDirectory' in props && props.workingDirectory) {
-      if (URL.canParse(props.workingDirectory)) {
-        const { pathname } = new URL(props.workingDirectory)
+    if (workingDirectory) {
+      if (URL.canParse(workingDirectory)) {
+        const { pathname } = new URL(workingDirectory)
         workingDirectory = pathname.slice(0, pathname.lastIndexOf('/'))
-      } else {
-        workingDirectory = props.workingDirectory
       }
+      source = new JavaScriptFile({
+        path: resolve(workingDirectory, source),
+      })
+    } else {
+      source = new JavaScriptFile({ path: source })
     }
-
-    source = new JavaScriptFile({
-      path: workingDirectory ? resolve(workingDirectory, source) : source,
-    })
   }
+
+  let data: ResolvedType | ResolvedType[] | undefined = undefined
 
   if (source instanceof JavaScriptFile) {
     const exportedTypes = await Promise.all(
-      (await source.getExports()).map((exportSource) =>
-        exportSource.getType(filter)
+      (await source.getExports()).map((fileExport) =>
+        fileExport.getType(filter)
       )
     )
-
-    return exportedTypes
-      .filter((type): type is ResolvedType => Boolean(type))
-      .map((type) => (
-        <div
-          key={type.name}
-          css={{
-            display: 'flex',
-            flexDirection: 'column',
-            padding: '1.6rem 0',
-            borderBottom: '1px solid var(--color-separator-secondary)',
-          }}
-        >
-          <div
-            css={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '0.8rem',
-            }}
-          >
-            <div
-              css={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '1rem',
-              }}
-            >
-              <h3
-                id={type.name ? createSlug(type.name, 'kebab') : undefined}
-                css={{ flexShrink: 0, margin: '0 !important' }}
-              >
-                {type.name}
-              </h3>
-
-              <CodeInline value={type.text} language="typescript" />
-
-              {/* {type.path && <ViewSource href={type.path} />} */}
-            </div>
-
-            {type.description ? (
-              <MDXRenderer
-                value={type.description}
-                components={mdxComponents}
-              />
-            ) : null}
-          </div>
-
-          <div css={{ display: 'flex' }}>
-            <TypeChildren type={type} css={{ marginTop: '2rem' }} />
-          </div>
-        </div>
-      ))
+    data = exportedTypes.filter((exportedType): exportedType is ResolvedType =>
+      Boolean(exportedType)
+    )
+  } else {
+    data = await source.getType(filter)
   }
 
-  const type = await source.getType(filter)
+  return data
+}
 
-  if (type === undefined) {
+const CurrentTypeContext = createContext<
+  | ResolvedType
+  | ClassAccessorType
+  | ClassMethodType
+  | FunctionSignatureType
+  | null
+>(null)
+
+function useCurrentType() {
+  return getContext(CurrentTypeContext)
+}
+
+function TypeProvider({
+  type,
+  children,
+}: {
+  type:
+    | ResolvedType
+    | ClassAccessorType
+    | ClassMethodType
+    | FunctionSignatureType
+  children?: React.ReactNode
+}) {
+  return <CurrentTypeContext value={type}>{children}</CurrentTypeContext>
+}
+
+export function TypeDisplay() {
+  const type = useCurrentType()
+  const { MDXRenderer, CodeInline } = useAPIReferenceConfig()
+
+  if (!type) {
     return null
   }
 
   return (
-    <div
-      key={type.name}
-      css={{
-        display: 'flex',
-        flexDirection: 'column',
-        padding: '1.6rem 0',
-        borderBottom: '1px solid var(--color-separator-secondary)',
-      }}
-    >
-      <div
-        css={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '0.8rem',
-        }}
-      >
-        <div
-          css={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '1rem',
-          }}
-        >
-          <h3
-            id={type.name ? createSlug(type.name, 'kebab') : undefined}
-            css={{ flexShrink: 0, margin: 0 }}
-          >
-            {type.name}
-          </h3>
+    <div>
+      <h3 id={type.name ? createSlug(type.name, 'kebab') : undefined}>
+        {type.name}
+      </h3>
 
-          <CodeInline value={type.text} language="typescript" />
+      <CodeInline value={type.text} language="typescript" />
 
-          {/* {type.path && <ViewSource href={type.path} />} */}
-        </div>
+      {type.description &&
+      type.kind !== 'Function' &&
+      type.kind !== 'Component' ? (
+        <MDXRenderer value={type.description} />
+      ) : null}
 
-        {type.description &&
-        type.kind !== 'Function' &&
-        type.kind !== 'Component' ? (
-          <MDXRenderer value={type.description} components={mdxComponents} />
-        ) : null}
-      </div>
-
-      <div css={{ display: 'flex' }}>
-        <TypeChildren type={type} css={{ marginTop: '2rem' }} />
-      </div>
+      <TypeChildren />
     </div>
   )
 }
 
-/** Determines how to render the immediate type children based on its kind. */
-function TypeChildren({
-  type,
-  css: cssProp,
-}: {
-  type: ResolvedType
-  css: CSSObject
-}) {
+export function TypeChildren() {
+  const type = useCurrentType()
+  const { CodeInline } = useAPIReferenceConfig()
+
+  if (!type) {
+    return null
+  }
+
   if (
     type.kind === 'Enum' ||
     type.kind === 'Symbol' ||
@@ -222,265 +222,97 @@ function TypeChildren({
     type.kind === 'Intersection' ||
     type.kind === 'Union'
   ) {
-    return <TypeProperties type={type} css={cssProp} />
+    return <TypeProperties />
   }
 
   if (type.kind === 'Class') {
-    return (
-      <div
-        css={{
-          display: 'flex',
-          flexDirection: 'column',
-          marginTop: '1.5rem',
-          gap: '1.2rem',
-          minWidth: 0,
-          ...cssProp,
-        }}
-      >
-        {type.accessors && type.accessors.length > 0 ? (
-          <div>
-            <h4 css={{ margin: 0 }}>Accessors</h4>
-            {type.accessors.map((accessor, index) => (
-              <TypeValue key={index} type={accessor} />
-            ))}
-          </div>
-        ) : null}
-
-        {type.constructors && type.constructors.length > 0 ? (
-          <div>
-            <h4 css={{ margin: 0 }}>Constructors</h4>
-            {type.constructors.map((constructor, index) => (
-              <TypeValue key={index} type={constructor} />
-            ))}
-          </div>
-        ) : null}
-
-        {type.methods && type.methods.length > 0 ? (
-          <div>
-            <h4 css={{ margin: 0 }}>Methods</h4>
-            {type.methods.map((method, index) => (
-              <TypeValue key={index} type={method} />
-            ))}
-          </div>
-        ) : null}
-
-        {type.properties && type.properties.length > 0 ? (
-          <div>
-            <h5 css={{ margin: 0 }}>Properties</h5>
-            {type.properties.map((property, index) => (
-              <TypeValue key={index} type={property} />
-            ))}
-          </div>
-        ) : null}
-      </div>
-    )
+    return <ClassKind />
   }
 
   if (type.kind === 'Component') {
-    return (
-      <div
-        css={{
-          display: 'flex',
-          flexDirection: 'column',
-          marginTop: '1.5rem',
-          gap: '1.2rem',
-          minWidth: 0,
-          ...cssProp,
-        }}
-      >
-        {type.signatures.length > 1 ? (
-          <h4 css={{ margin: 0, marginBottom: '1rem' }}>Overloads</h4>
-        ) : null}
-        {type.signatures.map((signature, index) => {
-          return (
-            <Fragment key={index}>
-              <hr
-                css={{
-                  border: 'none',
-                  borderTop: '1px solid var(--color-separator-secondary)',
-                }}
-              />
-              <CodeInline value={signature.text} language="typescript" />
-              {signature.description ? (
-                <MDXRenderer
-                  value={signature.description}
-                  components={mdxComponents}
-                />
-              ) : null}
-              {signature.parameter ? (
-                <div>
-                  <h5 css={{ margin: '0' }}>Parameters</h5>
-                  {signature.parameter.kind === 'Object' ? (
-                    <TypeProperties type={signature.parameter} />
-                  ) : signature.parameter.kind === 'Reference' ? (
-                    <CodeInline
-                      value={signature.parameter.text}
-                      language="typescript"
-                      css={{ display: 'inline-block', marginTop: '1.5rem' }}
-                    />
-                  ) : (
-                    <TypeValue type={signature.parameter} />
-                  )}
-                </div>
-              ) : null}
-              {signature.returnType ? (
-                <div>
-                  <h5 css={{ margin: 0, marginBottom: '1.5rem' }}>Returns</h5>
-                  {signature.returnType}
-                </div>
-              ) : null}
-            </Fragment>
-          )
-        })}
-      </div>
-    )
+    return <ComponentKind />
   }
 
   if (type.kind === 'Function') {
-    return (
-      <div
-        css={{
-          display: 'flex',
-          flexDirection: 'column',
-          marginTop: '1.5rem',
-          gap: '1.2rem',
-          minWidth: 0,
-          ...cssProp,
-        }}
-      >
-        {type.signatures.length > 1 ? (
-          <h4 css={{ margin: 0, marginBottom: '1rem' }}>Overloads</h4>
-        ) : null}
-        {type.signatures.map((signature, index) => {
-          return (
-            <Fragment key={index}>
-              <hr
-                css={{
-                  border: 'none',
-                  borderTop: '1px solid var(--color-separator-secondary)',
-                }}
-              />
-              <CodeInline value={signature.text} language="typescript" />
-              {signature.description ? (
-                <MDXRenderer
-                  value={signature.description}
-                  components={mdxComponents}
-                />
-              ) : null}
-              {signature.parameters.length > 0 ? (
-                <div>
-                  <h5 css={{ margin: 0 }}>Parameters</h5>
-                  {signature.parameters.map((parameter, index) => (
-                    <TypeValue key={index} type={parameter} />
-                  ))}
-                </div>
-              ) : null}
-              {signature.returnType ? (
-                <div
-                  css={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'start',
-                  }}
-                >
-                  <h5 css={{ margin: 0, marginBottom: '1.5rem' }}>Returns</h5>
-                  <CodeInline
-                    value={signature.returnType}
-                    language="typescript"
-                    css={{ maxWidth: '-webkit-fill-available' }}
-                  />
-                </div>
-              ) : null}
-            </Fragment>
-          )
-        })}
-      </div>
-    )
+    return <FunctionKind />
   }
 
   if (type.kind === 'Utility') {
     if (type.type) {
-      return <TypeChildren type={type.type} css={{ marginTop: '2rem' }} />
-    } else {
-      return <CodeInline value={type.text} language="typescript" />
+      return (
+        <TypeProvider type={type.type}>
+          <TypeChildren />
+        </TypeProvider>
+      )
     }
+    return <CodeInline value={type.text} language="typescript" />
   }
-
-  console.log('[APIReference:TypeChildren] Did not render: ', type)
 
   return null
 }
 
-/** Determines how to render the immediate type properties accounting for unions. */
-function TypeProperties({
-  type,
-  css: cssProp,
-}: {
-  type: TypeOfKind<'Object' | 'Intersection' | 'Union'>
-  css?: CSSObject
-}) {
+export function TypeProperties() {
+  const type = useCurrentType()
+
+  if (!type) {
+    return null
+  }
+
   if (type.kind === 'Union') {
     return (
-      <div
-        css={{
-          display: 'flex',
-          flexDirection: 'column',
-          marginTop: '1.5rem',
-          gap: '1.2rem',
-          minWidth: 0,
-          ...cssProp,
-        }}
-      >
-        {type.members.map((member, index) =>
-          member.kind === 'Object' ||
-          member.kind === 'Intersection' ||
-          member.kind === 'Union' ? (
-            <TypeProperties key={index} type={member} />
-          ) : member.kind === 'Reference' ? (
-            member.text
-          ) : (
-            <TypeValue key={index} type={member} />
+      <div>
+        {type.members.map((member, index) => {
+          if (
+            member.kind === 'Object' ||
+            member.kind === 'Intersection' ||
+            member.kind === 'Union'
+          ) {
+            return (
+              <TypeProvider key={index} type={member}>
+                <TypeProperties />
+              </TypeProvider>
+            )
+          }
+          if (member.kind === 'Reference') {
+            return <Fragment key={index}>{member.text}</Fragment>
+          }
+          return (
+            <TypeProvider key={index} type={member}>
+              <TypeValue />
+            </TypeProvider>
           )
-        )}
+        })}
       </div>
     )
   }
 
-  if (type.properties.length) {
+  if (
+    (type.kind === 'Object' || type.kind === 'Intersection') &&
+    type.properties?.length
+  ) {
     return (
-      <div
-        css={{
-          display: 'flex',
-          flexDirection: 'column',
-          marginTop: '1.5rem',
-          gap: '1.2rem',
-          minWidth: 0,
-          ...cssProp,
-        }}
-      >
-        <h5 css={{ margin: 0, color: 'var(--color-foreground-secondary)' }}>
-          Properties
-        </h5>
-        {type.properties.map((propertyType, index) => (
-          <TypeValue key={index} type={propertyType} />
+      <div>
+        <h5>Properties</h5>
+        {type.properties.map((prop, index) => (
+          <TypeProvider key={index} type={prop}>
+            <TypeValue />
+          </TypeProvider>
         ))}
       </div>
     )
   }
 
-  console.log('[APIReference:TypeProperties] Did not render: ', type)
-
   return null
 }
 
-/** Renders a type value with its name, type, and description. */
-function TypeValue({
-  type,
-  css: cssProp,
-}: {
-  type: AllTypes
-  css?: CSSObject
-}) {
+export function TypeValue() {
+  const type = useCurrentType()
+  const { MDXRenderer, CodeInline } = useAPIReferenceConfig()
+
+  if (!type) {
+    return null
+  }
+
   const isNameSameAsType = type.name === type.text
   let isRequired = false
   let defaultValue
@@ -491,103 +323,210 @@ function TypeValue({
   }
 
   return (
-    <div
-      key={type.name + type.text}
-      css={{
-        display: 'flex',
-        flexDirection: 'column',
-        padding: '1.5rem 0',
-        gap: '0.8rem',
-        minWidth: 0,
-        ...cssProp,
-      }}
-    >
-      <div
-        css={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 8,
-        }}
-      >
-        <h4
-          css={{
-            display: 'flex',
-            alignItems: 'flex-start',
-            flexShrink: 0,
-            margin: 0,
-            fontWeight: 400,
-            color: 'var(--color-foreground-secondary)',
-          }}
-        >
-          {type.name}{' '}
-          {isRequired && (
-            <span css={{ color: 'oklch(0.8 0.15 36.71)' }} title="required">
-              *
-            </span>
-          )}
-        </h4>
-        <div
-          css={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.25rem',
-            minWidth: 0,
-          }}
-        >
-          {isNameSameAsType ? null : (
+    <div>
+      <div>
+        <strong>{type.name}</strong> {isRequired && <span>*</span>}
+        {!isNameSameAsType && (
+          <>
+            {' '}
+            <CodeInline value={type.text} language="typescript" />
+          </>
+        )}
+        {defaultValue !== undefined && (
+          <>
+            {' = '}
             <CodeInline
-              value={type.text}
+              value={JSON.stringify(defaultValue)}
               language="typescript"
-              paddingX="0.5rem"
-              paddingY="0.2rem"
-              css={{ fontSize: 'var(--font-size-body-2)' }}
             />
-          )}
-          {defaultValue ? (
-            <span
-              css={{
-                flexShrink: 0,
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.25rem',
-                minWidth: 0,
-              }}
-            >
-              ={' '}
-              <CodeInline
-                value={JSON.stringify(defaultValue)}
-                language="typescript"
-              />
-            </span>
-          ) : null}
-        </div>
+          </>
+        )}
       </div>
 
       {type.description && (
-        <MDXRenderer value={type.description} components={mdxComponents} />
+        <div>
+          <MDXRenderer value={type.description} />
+        </div>
       )}
 
+      {/* Nested object properties */}
       {type.kind === 'Object' && type.properties
-        ? type.properties.map((propertyType, index) => (
-            <TypeValue
-              key={index}
-              type={propertyType}
-              css={{ paddingLeft: '1.5rem' }}
-            />
+        ? type.properties.map((child, index) => (
+            <TypeProvider key={index} type={child}>
+              <div style={{ marginLeft: '1.5rem' }}>
+                <TypeValue />
+              </div>
+            </TypeProvider>
           ))
         : null}
 
-      {type.kind === 'Function' && type.signatures && type.signatures.length
-        ? type.signatures.map((signature) =>
-            signature.parameters.map((parameter, index) => (
-              <TypeValue
-                key={index}
-                type={parameter}
-                css={{ paddingLeft: '1.5rem' }}
-              />
-            ))
-          )
+      {/* If it's a function, render signatures/parameters */}
+      {type.kind === 'Function' && type.signatures
+        ? type.signatures.map((sig, index) => (
+            <Fragment key={index}>
+              {sig.parameters.map((param, i2) => (
+                <TypeProvider key={i2} type={param}>
+                  <div style={{ marginLeft: '1.5rem' }}>
+                    <TypeValue />
+                  </div>
+                </TypeProvider>
+              ))}
+            </Fragment>
+          ))
         : null}
+    </div>
+  )
+}
+
+export function ClassKind() {
+  const type = useCurrentType()
+
+  if (!type) {
+    return null
+  }
+
+  if (type.kind === 'Class') {
+    return (
+      <div>
+        {type.accessors && type.accessors.length > 0 && (
+          <div>
+            <h4>Accessors</h4>
+            {type.accessors.map((accessorType, index) => (
+              <TypeProvider key={index} type={accessorType}>
+                <TypeValue />
+              </TypeProvider>
+            ))}
+          </div>
+        )}
+
+        {type.constructors && type.constructors.length > 0 && (
+          <div>
+            <h4>Constructors</h4>
+            {type.constructors.map((constructorType, index) => (
+              <TypeProvider key={index} type={constructorType}>
+                <TypeValue />
+              </TypeProvider>
+            ))}
+          </div>
+        )}
+
+        {type.methods && type.methods.length > 0 && (
+          <div>
+            <h4>Methods</h4>
+            {type.methods.map((methodType, index) => (
+              <TypeProvider key={index} type={methodType}>
+                <TypeValue />
+              </TypeProvider>
+            ))}
+          </div>
+        )}
+
+        {type.properties && type.properties.length > 0 && (
+          <div>
+            <h5>Properties</h5>
+            {type.properties.map((propertyType, index) => (
+              <TypeProvider key={index} type={propertyType}>
+                <TypeValue />
+              </TypeProvider>
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return null
+}
+
+export function FunctionKind() {
+  const { MDXRenderer, CodeInline } = useAPIReferenceConfig()
+  const type = useCurrentType()
+
+  if (!type || type.kind !== 'Function') {
+    return null
+  }
+
+  const { signatures } = type
+  return (
+    <div>
+      {signatures.length > 1 && <h4>Overloads</h4>}
+      {signatures.map((signature, index) => (
+        <Fragment key={index}>
+          <hr />
+          <CodeInline value={signature.text} language="typescript" />
+          {signature.description && (
+            <div>
+              <MDXRenderer value={signature.description} />
+            </div>
+          )}
+          {signature.parameters.length > 0 && (
+            <div>
+              <h5>Parameters</h5>
+              {signature.parameters.map((param, i2) => (
+                <TypeProvider key={i2} type={param}>
+                  <TypeValue />
+                </TypeProvider>
+              ))}
+            </div>
+          )}
+          {signature.returnType && (
+            <div>
+              <h5>Returns</h5>
+              <CodeInline value={signature.returnType} language="typescript" />
+            </div>
+          )}
+        </Fragment>
+      ))}
+    </div>
+  )
+}
+
+export function ComponentKind() {
+  const { MDXRenderer, CodeInline } = useAPIReferenceConfig()
+  const type = useCurrentType()
+
+  if (!type || type.kind !== 'Component') {
+    return null
+  }
+
+  const { signatures } = type
+  return (
+    <div>
+      {signatures.length > 1 && <h4>Overloads</h4>}
+      {signatures.map((signature, index) => (
+        <Fragment key={index}>
+          <hr />
+          <CodeInline value={signature.text} language="typescript" />
+          {signature.description ? (
+            <MDXRenderer value={signature.description} />
+          ) : null}
+          {signature.parameter && (
+            <div>
+              <h5>Parameters</h5>
+              {signature.parameter.kind === 'Object' ? (
+                <TypeProvider type={signature.parameter}>
+                  <TypeProperties />
+                </TypeProvider>
+              ) : signature.parameter.kind === 'Reference' ? (
+                <CodeInline
+                  value={signature.parameter.text}
+                  language="typescript"
+                />
+              ) : (
+                <TypeProvider type={signature.parameter}>
+                  <TypeValue />
+                </TypeProvider>
+              )}
+            </div>
+          )}
+          {signature.returnType && (
+            <div>
+              <h5>Returns</h5>
+              {signature.returnType}
+            </div>
+          )}
+        </Fragment>
+      ))}
     </div>
   )
 }

--- a/packages/renoun/src/components/index.ts
+++ b/packages/renoun/src/components/index.ts
@@ -1,4 +1,14 @@
-export { APIReference } from './APIReference.js'
+export {
+  APIReference,
+  ClassKind,
+  ComponentKind,
+  FunctionKind,
+  TypeChildren,
+  TypeDisplay,
+  TypeProperties,
+  TypeValue,
+  type APIReferenceProps,
+} from './APIReference.js'
 export {
   CodeBlock,
   CopyButton,


### PR DESCRIPTION
Updates the `APIReference` component to make it easier to override rendering, previously this was all or nothing and you needed to either use the default styles or override the entire component's rendering. This improves the customization story by introducing a new `components` prop that can target each descendant component:

```tsx
<APIReference
  source={...}
  components={{ Type: ({ name, isOptional, children }) => ... }}
/>
```