### PR TITLE
theme overrides

### DIFF
--- a/.changeset/slimy-chairs-travel.md
+++ b/.changeset/slimy-chairs-travel.md
@@ -1,0 +1,24 @@
+---
+'renoun': minor
+---
+
+Adds the ability to override specific theme values. You can now provide a tuple when configuring themes that specifies the specific theme values to override:
+
+```json
+{
+  "theme": {
+    "light": "vitesse-light",
+    "dark": [
+      "vitesse-dark",
+      {
+        "colors": {
+          "editor.background": "#000000",
+          "panel.border": "#666666"
+        }
+      }
+    ]
+  }
+}
+```
+
+This accepts a subset of a VS Code theme to override, specifically the `colors`, `tokenColors`, and `semanticTokenColors` properties.

--- a/apps/site/app/schema.json/route.ts
+++ b/apps/site/app/schema.json/route.ts
@@ -14,13 +14,64 @@ const themeValueSchema = z.union([
     ),
 ])
 
-const themeSchema = z.union([
+const themeOverrideSchema = z
+  .object({
+    colors: z
+      .record(z.string())
+      .optional()
+      .describe('Overrides for theme colors.'),
+    tokenColors: z
+      .array(
+        z.object({
+          scope: z
+            .union([z.string(), z.array(z.string())])
+            .optional()
+            .describe(
+              'One or more token scopes where the settings will be applied.'
+            ),
+          settings: z
+            .object({
+              foreground: z
+                .string()
+                .optional()
+                .describe('The foreground color.'),
+              background: z
+                .string()
+                .optional()
+                .describe('The background color.'),
+              fontStyle: z
+                .string()
+                .optional()
+                .describe(
+                  'Font style (e.g. "italic", "bold", or a combination thereof).'
+                ),
+            })
+            .optional()
+            .describe('Token style settings.'),
+        })
+      )
+      .optional()
+      .describe('Overrides for token colors.'),
+    semanticTokenColors: z
+      .record(z.union([z.string(), z.object({}).passthrough()]))
+      .optional()
+      .describe('Overrides for semantic token colors.'),
+  })
+  .passthrough()
+  .describe('Theme override configuration.')
+
+const themeOptionSchema = z.union([
   themeValueSchema,
+  z.tuple([themeValueSchema, themeOverrideSchema]),
+])
+
+const themeSchema = z.union([
+  themeOptionSchema,
   z
     .object({})
-    .catchall(themeValueSchema)
+    .catchall(themeOptionSchema)
     .describe(
-      `Define multiple named themes using an object \`{ light: 'vitesse-light', dark: 'vitesse-dark' }\`. The first theme defined in the object will be used as the default theme.`
+      `Define multiple named themes using an object, e.g. { light: 'vitesse-light', dark: 'vitesse-dark' }. The first theme defined in the object will be used as the default theme.`
     ),
 ])
 

--- a/apps/site/docs/03.configuration.mdx
+++ b/apps/site/docs/03.configuration.mdx
@@ -98,6 +98,29 @@ To use a specific theme, append a `data-theme` attribute to the `html` element o
 </html>
 ```
 
+### Overriding Themes
+
+To override a theme, you can provide a tuple that specifies the theme values to override:
+
+```json
+{
+  "theme": {
+    "light": "vitesse-light",
+    "dark": [
+      "vitesse-dark",
+      {
+        "colors": {
+          "editor.background": "#000000",
+          "panel.border": "#666666"
+        }
+      }
+    ]
+  }
+}
+```
+
+This accepts a subset of a VS Code theme to override, specifically the `colors`, `tokenColors`, and `semanticTokenColors` properties.
+
 ## Languages
 
 The `languages` property is used to define the languages that are supported by the `CodeBlock` and `CodeInline` components. This is used to determine which language to load when highlighting code.

--- a/examples/design-system/renoun.json
+++ b/examples/design-system/renoun.json
@@ -5,7 +5,14 @@
   },
   "siteUrl": "https://renoun.dev",
   "theme": {
-    "dark": "vitesse-dark",
-    "light": "vitesse-light"
+    "light": "everforest-light",
+    "dark": [
+      "dracula-soft",
+      {
+        "colors": {
+          "panel.border": "#666"
+        }
+      }
+    ]
   }
 }

--- a/packages/renoun/src/utils/create-highlighter.ts
+++ b/packages/renoun/src/utils/create-highlighter.ts
@@ -13,9 +13,15 @@ export async function createHighlighter() {
     themes = [await getTheme(config.theme)]
   } else {
     themes = await Promise.all(
-      Object.entries(config.theme).map(([name, theme]) =>
-        theme.endsWith('.json') ? getTheme(name) : theme
-      )
+      Object.entries(config.theme).map(([name, theme]) => {
+        if (typeof theme === 'string' && theme.endsWith('.json')) {
+          return getTheme(name)
+        } else if (Array.isArray(theme)) {
+          return theme[0]
+        } else {
+          return theme
+        }
+      })
     )
   }
 

--- a/packages/renoun/src/utils/get-tokens.ts
+++ b/packages/renoun/src/utils/get-tokens.ts
@@ -124,7 +124,12 @@ export async function getTokens(
   const themeNames =
     typeof config.theme === 'string'
       ? [config.theme]
-      : Object.values(config.theme)
+      : Object.values(config.theme).map((theme) => {
+          if (typeof theme === 'string') {
+            return theme
+          }
+          return theme[0]
+        })
   let themedTokens: ReturnType<Highlighter['codeToTokens']>['tokens'][] = []
 
   try {


### PR DESCRIPTION
Adds the ability to override specific theme values. You can now provide a tuple when configuring themes that specifies the specific theme values to override:

```json
{
  "theme": {
    "light": "vitesse-light",
    "dark": [
      "vitesse-dark",
      {
        "colors": {
          "editor.background": "#000000",
          "panel.border": "#666666"
        }
      }
    ]
  }
}
```

This accepts a subset of a VS Code theme to override, specifically the `colors`, `tokenColors`, and `semanticTokenColors` properties.