### PR TITLE
add MDXFile class

### DIFF
--- a/.changeset/legal-terms-drop.md
+++ b/.changeset/legal-terms-drop.md
@@ -1,0 +1,5 @@
+---
+'renoun': minor
+---
+
+Adds `MDXFile` class to differentiate between specific MDX and JavaScript file methods.

--- a/.changeset/legal-terms-drop.md
+++ b/.changeset/legal-terms-drop.md
@@ -2,4 +2,8 @@
 'renoun': minor
 ---
 
-Adds `MDXFile` class to differentiate between specific MDX and JavaScript file methods.
+Adds `MDXFile`, `MDXFileExport`, and `isMDXFile` classes and utilities to better differentiate between specific MDX and JavaScript file methods. This also helps with performance since we should never attempt to analyze an MDX file using the TypeScript compiler and allows for future MDX-specific methods to be added.
+
+### Breaking Changes
+
+In some cases there may be breaking changes if you were loading mdx files and targeting `JavaScriptFile` related classes or types. These should be transitioned to the new `MDXFile`, `MDXFileExport`, and `isMDXFile` respectively.

--- a/apps/site/components/DocumentEntry.tsx
+++ b/apps/site/components/DocumentEntry.tsx
@@ -1,4 +1,4 @@
-import type { EntryGroup, JavaScriptFile } from 'renoun/file-system'
+import type { EntryGroup, MDXFile } from 'renoun/file-system'
 import type { MDXContent, MDXHeadings } from 'renoun/mdx'
 
 import { SiblingLink } from './SiblingLink'
@@ -10,7 +10,7 @@ export async function DocumentEntry({
   shouldRenderTableOfContents = true,
   shouldRenderUpdatedAt = true,
 }: {
-  file: JavaScriptFile<{
+  file: MDXFile<{
     default: MDXContent
     headings: MDXHeadings
     metadata: {

--- a/apps/site/components/SiblingLink.tsx
+++ b/apps/site/components/SiblingLink.tsx
@@ -4,8 +4,10 @@ import {
   FileNotFoundError,
   isDirectory,
   isJavaScriptFile,
+  isMDXFile,
   type FileSystemEntry,
   type JavaScriptFile,
+  type MDXFile,
 } from 'renoun/file-system'
 import { styled } from 'restyle'
 
@@ -124,7 +126,7 @@ interface Metadata {
 
 /** Resolves metadata from a file system entry. */
 async function resolveEntryMetadata(entry: FileSystemEntry) {
-  let file: JavaScriptFile<Metadata>
+  let file: JavaScriptFile<Metadata> | MDXFile<Metadata>
 
   if (isDirectory(entry)) {
     const indexFile = await entry
@@ -152,7 +154,7 @@ async function resolveEntryMetadata(entry: FileSystemEntry) {
         return
       }
     }
-  } else if (isJavaScriptFile<Metadata>(entry)) {
+  } else if (isJavaScriptFile<Metadata>(entry) || isMDXFile<Metadata>(entry)) {
     file = entry
   } else {
     return

--- a/packages/renoun/package.json
+++ b/packages/renoun/package.json
@@ -106,6 +106,7 @@
     "react-dom": ">=18.0.0"
   },
   "devDependencies": {
+    "@mdx-js/rollup": "^3.1.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@types/title": "^3.4.3",

--- a/packages/renoun/src/file-system/index.test.ts
+++ b/packages/renoun/src/file-system/index.test.ts
@@ -15,6 +15,8 @@ import {
   Directory,
   JavaScriptFile,
   JavaScriptFileExport,
+  MDXFile,
+  MDXFileExport,
   EntryGroup,
   isDirectory,
   isFile,
@@ -24,7 +26,6 @@ import {
   FileExportNotFoundError,
 } from './index'
 import type { Expect, Is, IsNotAny } from './types'
-import { title } from 'node:process'
 
 describe('file system', () => {
   describe('File', () => {
@@ -407,7 +408,7 @@ describe('file system', () => {
     const files = await posts.getEntries()
 
     expectTypeOf(files).toMatchTypeOf<
-      JavaScriptFile<{ default: MDXContent } & PostType>[]
+      MDXFile<{ default: MDXContent } & PostType>[]
     >()
     expect(files).toHaveLength(1)
   })
@@ -429,7 +430,7 @@ describe('file system', () => {
     const files = await posts.getEntries()
 
     expectTypeOf(files).toMatchTypeOf<
-      JavaScriptFile<{ default: MDXContent } & PostType>[]
+      MDXFile<{ default: MDXContent } & PostType>[]
     >()
     expect(files).toHaveLength(1)
   })
@@ -476,9 +477,7 @@ describe('file system', () => {
     })
     const entries = await directory.getEntries()
 
-    expectTypeOf(entries).toMatchTypeOf<
-      JavaScriptFile<{ default: MDXContent }>[]
-    >()
+    expectTypeOf(entries).toMatchTypeOf<MDXFile<{ default: MDXContent }>[]>()
 
     expect(entries).toHaveLength(1)
   })
@@ -1329,7 +1328,7 @@ describe('file system', () => {
     expect(isDirectory(file)).toBe(false)
 
     expectTypeOf(file).toMatchTypeOf<
-      JavaScriptFile<{
+      MDXFile<{
         default: MDXContent
         frontmatter: {
           title: string
@@ -1433,7 +1432,7 @@ describe('file system', () => {
 
     expect(mdxFile).toBeInstanceOf(JavaScriptFile)
     expectTypeOf(mdxFile).toMatchTypeOf<
-      JavaScriptFile<{ default: MDXContent } & InferModuleExports<FrontMatter>>
+      MDXFile<{ default: MDXContent } & InferModuleExports<FrontMatter>>
     >()
 
     const file = await group.getFile(['posts', 'meta'], 'js')
@@ -1549,7 +1548,7 @@ describe('file system', () => {
     const file = await group.getFile('Button', 'mdx')
 
     expectTypeOf(file).toMatchTypeOf<
-      JavaScriptFile<{ default: MDXContent } & MDXTypes>
+      MDXFile<{ default: MDXContent } & MDXTypes>
     >()
 
     const entry = await group.getEntry('Button')
@@ -1562,14 +1561,14 @@ describe('file system', () => {
 
     if (directoryA.hasFile(entry, 'mdx')) {
       expectTypeOf(entry).toMatchTypeOf<
-        JavaScriptFile<{ default: MDXContent } & MDXTypes>
+        MDXFile<{ default: MDXContent } & MDXTypes>
       >()
     }
   })
 
   test('entry group works with type abstractions', async () => {
     function Document(props: {
-      file?: JavaScriptFile<{
+      file?: MDXFile<{
         default: MDXContent
         headings: MDXHeadings
         metadata: {

--- a/packages/renoun/src/file-system/index.test.ts
+++ b/packages/renoun/src/file-system/index.test.ts
@@ -197,7 +197,7 @@ describe('file system', () => {
               date: z.coerce.date(),
             }),
           },
-          (path) => import(`./posts/${path}.mdx`)
+          (path) => import(`#fixtures/posts/${path}.mdx`)
         ),
       },
       include: async (entry) => {
@@ -1430,7 +1430,7 @@ describe('file system', () => {
       'mdx'
     )
 
-    expect(mdxFile).toBeInstanceOf(JavaScriptFile)
+    expect(mdxFile).toBeInstanceOf(MDXFile)
     expectTypeOf(mdxFile).toMatchTypeOf<
       MDXFile<{ default: MDXContent } & InferModuleExports<FrontMatter>>
     >()

--- a/packages/renoun/src/file-system/index.tsx
+++ b/packages/renoun/src/file-system/index.tsx
@@ -67,7 +67,7 @@ const defaultLoaders: Record<string, ModuleLoader<any>> = {
 /** A function that resolves the module runtime. */
 type ModuleRuntimeLoader<Value> = (
   path: string,
-  file: JavaScriptFile<any>
+  file: File<any> | JavaScriptFile<any> | MDXFile<any>
 ) => Promise<Value>
 
 /** A record of named exports in a module. */
@@ -252,8 +252,8 @@ export class FileNotFoundError extends Error {
 
 /** A directory or file entry. */
 export type FileSystemEntry<
-  Types extends Record<string, any> = Record<string, any>,
-> = Directory<Types> | File<Types>
+  DirectoryTypes extends Record<string, any> = Record<string, any>,
+> = Directory<DirectoryTypes> | File<DirectoryTypes>
 
 /** Options for a file in the file system. */
 export interface FileOptions<
@@ -273,7 +273,7 @@ export interface FileOptions<
 
 /** A file in the file system. */
 export class File<
-  Types extends Record<string, any> = Record<string, any>,
+  DirectoryTypes extends Record<string, any> = Record<string, any>,
   Path extends string = string,
   Extension extends string = ExtractFileExtension<Path>,
 > {
@@ -285,9 +285,9 @@ export class File<
   #path: string
   #slugCasing: SlugCasings
   #depth: number
-  #directory: Directory<Types>
+  #directory: Directory<DirectoryTypes>
 
-  constructor(options: FileOptions<Types, Path>) {
+  constructor(options: FileOptions<DirectoryTypes, Path>) {
     this.#name = baseName(options.path)
     this.#path = options.path
     this.#slugCasing = options.slugCasing ?? 'kebab'
@@ -503,11 +503,16 @@ export class File<
    * Get the previous and next sibling entries (files or directories) of the parent directory.
    * If the file is an index or readme file, the siblings will be retrieved from the parent directory.
    */
-  async getSiblings<GroupTypes extends Record<string, any> = Types>(options?: {
+  async getSiblings<
+    GroupTypes extends Record<string, any> = DirectoryTypes,
+  >(options?: {
     entryGroup?: EntryGroup<GroupTypes, FileSystemEntry<any>[]>
     includeDuplicateSegments?: boolean
   }): Promise<
-    [FileSystemEntry<Types> | undefined, FileSystemEntry<Types> | undefined]
+    [
+      FileSystemEntry<DirectoryTypes> | undefined,
+      FileSystemEntry<DirectoryTypes> | undefined,
+    ]
   > {
     const isIndexOrReadme = ['index', 'readme'].includes(
       this.getBaseName().toLowerCase()
@@ -826,22 +831,27 @@ export class JavaScriptFileExport<Value> {
 /** Options for a JavaScript file in the file system. */
 export interface JavaScriptFileOptions<
   Types extends Record<string, any>,
+  DirectoryTypes extends Record<string, any>,
   Path extends string,
-> extends FileOptions<Types, Path> {
+> extends FileOptions<DirectoryTypes, Path> {
   loader?: ModuleLoader<Types>
 }
 
 /** A JavaScript file in the file system. */
 export class JavaScriptFile<
   Types extends InferDefaultModuleTypes<Path>,
+  DirectoryTypes extends Record<string, any> = Record<string, any>,
   const Path extends string = string,
   Extension extends string = ExtractFileExtension<Path>,
-> extends File<Types, Path, Extension> {
+> extends File<DirectoryTypes, Path, Extension> {
   #exports = new Map<string, JavaScriptFileExport<any>>()
   #loader?: ModuleLoader<Types>
   #slugCasing?: SlugCasings
 
-  constructor({ loader, ...fileOptions }: JavaScriptFileOptions<Types, Path>) {
+  constructor({
+    loader,
+    ...fileOptions
+  }: JavaScriptFileOptions<Types, DirectoryTypes, Path>) {
     super(fileOptions)
 
     if (loader === undefined) {
@@ -1032,6 +1042,198 @@ export class JavaScriptFile<
     }
 
     return false
+  }
+}
+
+/** An MDX file export. */
+export class MDXFileExport<Value> {
+  #name: string
+  #file: MDXFile<any>
+  #loader?: ModuleLoader<any>
+  #slugCasing: SlugCasings
+
+  constructor(
+    name: string,
+    file: MDXFile<any>,
+    loader?: ModuleLoader<any>,
+    slugCasing?: SlugCasings
+  ) {
+    this.#name = name
+    this.#file = file
+    this.#loader = loader
+    this.#slugCasing = slugCasing ?? 'kebab'
+  }
+
+  getName() {
+    return this.#name
+  }
+
+  getTitle() {
+    return formatNameAsTitle(this.getName())
+  }
+
+  getSlug() {
+    return createSlug(this.getName(), this.#slugCasing)
+  }
+
+  getEditorUri() {
+    return this.#file.getEditorUri()
+  }
+
+  getEditUrl(options?: Pick<GetFileUrlOptions, 'ref'>) {
+    return this.#file.getEditUrl(options)
+  }
+
+  getSourceUrl(options?: Pick<GetFileUrlOptions, 'ref'>) {
+    return this.#file.getSourceUrl(options)
+  }
+
+  async getRuntimeValue(): Promise<Value> {
+    const fileModule = await this.#getModule()
+
+    if (!(this.#name in fileModule)) {
+      throw new FileExportNotFoundError(
+        this.#file.getAbsolutePath(),
+        this.#name
+      )
+    }
+
+    return fileModule[this.#name]
+  }
+
+  #getModule() {
+    if (!this.#loader) {
+      const parentPath = this.#file.getParent().getRelativePathToWorkspace()
+      throw new Error(
+        `[renoun] No mdx loader defined for directory at "${parentPath}".`
+      )
+    }
+    const path = removeExtension(this.#file.getRelativePath())
+
+    if (isLoader(this.#loader)) {
+      return this.#loader(path, this as any)
+    }
+
+    if (isLoaderWithSchema(this.#loader) && this.#loader.runtime) {
+      if (!this.#loader.runtime) {
+        throw new Error(`[renoun] No mdx runtime loader configured.`)
+      }
+      return this.#loader.runtime(path, this.#file)
+    }
+
+    throw new Error(`[renoun] Invalid mdx loader: missing runtime function.`)
+  }
+}
+
+/** Options for an MDX file in the file system. */
+export interface MDXFileOptions<
+  Types extends Record<string, any>,
+  DirectoryTypes extends Record<string, any>,
+  Path extends string,
+> extends FileOptions<DirectoryTypes, Path> {
+  loader?: ModuleLoader<Types>
+}
+
+/** An MDX file in the file system. */
+export class MDXFile<
+  Types extends InferDefaultModuleTypes<Path>,
+  DirectoryTypes extends Record<string, any> = any,
+  const Path extends string = string,
+  Extension extends string = ExtractFileExtension<Path>,
+> extends File<DirectoryTypes, Path, Extension> {
+  #exports = new Map<string, MDXFileExport<any>>()
+  #loader?: ModuleLoader<Types>
+  #slugCasing?: SlugCasings
+
+  constructor({
+    loader,
+    ...fileOptions
+  }: MDXFileOptions<Types, DirectoryTypes, Path>) {
+    super(fileOptions)
+
+    if (loader === undefined) {
+      this.#loader = defaultLoaders.mdx
+    } else {
+      this.#loader = loader
+    }
+
+    this.#slugCasing = fileOptions.slugCasing ?? 'kebab'
+  }
+
+  async getExports() {
+    const fileModule = await this.#getModule()
+    const exportNames = Object.keys(fileModule)
+
+    for (const name of exportNames) {
+      if (!this.#exports.has(name)) {
+        const mdxExport = new MDXFileExport(
+          name,
+          this as MDXFile<any>,
+          this.#loader,
+          this.#slugCasing
+        )
+        this.#exports.set(name, mdxExport)
+      }
+    }
+
+    return Array.from(this.#exports.values())
+  }
+
+  async getExport<ExportName extends Extract<keyof Types, string>>(
+    name: ExportName
+  ): Promise<MDXFileExport<Types[ExportName]>> {
+    if (this.#exports.has(name)) {
+      return this.#exports.get(name)!
+    }
+
+    const fileModule = await this.#getModule()
+    if (!(name in fileModule)) {
+      throw new FileExportNotFoundError(this.getAbsolutePath(), name)
+    }
+
+    const mdxExport = new MDXFileExport<Types[ExportName]>(
+      name,
+      this as MDXFile<any>,
+      this.#loader,
+      this.#slugCasing
+    )
+    this.#exports.set(name, mdxExport)
+    return mdxExport
+  }
+
+  async hasExport(name: string): Promise<boolean> {
+    const fileModule = await this.#getModule()
+    return name in fileModule
+  }
+
+  async getExportValue<ExportName extends Extract<keyof Types, string>>(
+    name: ExportName
+  ): Promise<Types[ExportName]> {
+    const mdxExport = await this.getExport(name)
+    return mdxExport.getRuntimeValue()
+  }
+
+  #getModule() {
+    if (!this.#loader) {
+      const parentPath = this.getParent().getRelativePathToWorkspace()
+      throw new Error(
+        `[renoun] A loader for mdx is not defined in directory "${parentPath}".`
+      )
+    }
+    const path = removeExtension(this.getRelativePath())
+
+    if (isLoader(this.#loader)) {
+      return this.#loader(path, this as any)
+    }
+
+    if (isLoaderWithSchema(this.#loader) && this.#loader.runtime) {
+      if (!this.#loader.runtime) {
+        throw new Error(`[renoun] No mdx runtime loader is defined.`)
+      }
+      return this.#loader.runtime(path, this as any)
+    }
+
+    throw new Error(`[renoun] This mdx loader is missing a runtime function.`)
   }
 }
 
@@ -1235,8 +1437,10 @@ export class Directory<
   ): Promise<
     Extension extends string
       ? IsJavaScriptLikeExtension<Extension> extends true
-        ? JavaScriptFile<LoaderTypes[Extension], string, Extension>
-        : File<LoaderTypes, Path, Extension>
+        ? JavaScriptFile<LoaderTypes[Extension], LoaderTypes, string, Extension>
+        : Extension extends 'mdx'
+          ? MDXFile<LoaderTypes['mdx'], LoaderTypes, string, Extension>
+          : File<LoaderTypes, Path, Extension>
       : File<LoaderTypes>
   >
 
@@ -1249,8 +1453,10 @@ export class Directory<
   ): Promise<
     Extension extends string
       ? IsJavaScriptLikeExtension<Extension> extends true
-        ? JavaScriptFile<LoaderTypes[Extension], string, Extension>
-        : File<LoaderTypes, Extension>
+        ? JavaScriptFile<LoaderTypes[Extension], LoaderTypes, string, Extension>
+        : Extension extends 'mdx'
+          ? MDXFile<LoaderTypes['mdx'], LoaderTypes, string, Extension>
+          : File<LoaderTypes, Extension>
       : File<LoaderTypes>
   >
 
@@ -1563,12 +1769,20 @@ export class Directory<
                 slugCasing: this.#slugCasing,
                 loader,
               })
-            : new File({
-                path: entry.path,
-                depth: nextDepth,
-                directory: thisDirectory,
-                slugCasing: this.#slugCasing,
-              })
+            : extension === 'mdx'
+              ? new MDXFile({
+                  path: entry.path,
+                  depth: nextDepth,
+                  directory: thisDirectory,
+                  slugCasing: this.#slugCasing,
+                  loader,
+                })
+              : new File({
+                  path: entry.path,
+                  depth: nextDepth,
+                  directory: thisDirectory,
+                  slugCasing: this.#slugCasing,
+                })
 
         if (
           !options?.includeDuplicates &&
@@ -1961,7 +2175,9 @@ export class EntryGroup<
     Extension extends string
       ? IsJavaScriptLikeExtension<Extension> extends true
         ? JavaScriptFile<Types[Extension]>
-        : File<Types>
+        : Extension extends 'mdx'
+          ? MDXFile<Types['mdx']>
+          : File<Types>
       : File<Types>
   > {
     const normalizedPath = Array.isArray(path)
@@ -2051,12 +2267,16 @@ export type FileWithExtension<
   Extension = LoadersToExtensions<Types>,
 > = Extension extends string
   ? IsJavaScriptLikeExtension<Extension> extends true
-    ? JavaScriptFile<Types[Extension], any, Extension>
-    : File<Types>
+    ? JavaScriptFile<Types[Extension], Types, any, Extension>
+    : Extension extends 'mdx'
+      ? MDXFile<Types['mdx'], Types, any, Extension>
+      : File<Types>
   : Extension extends string[]
     ? HasJavaScriptLikeExtensions<Extension> extends true
-      ? JavaScriptFile<Types[Extension[number]], any, Extension[number]>
-      : File<Types>
+      ? JavaScriptFile<Types[Extension[number]], Types, any, Extension[number]>
+      : Extension[number] extends 'mdx'
+        ? MDXFile<Types['mdx'], Types, any, Extension[number]>
+        : File<Types>
     : File<Types>
 
 type StringUnion<Type> = Extract<Type, string> | (string & {})
@@ -2077,11 +2297,7 @@ export function isFile<
 >(
   entry: FileSystemEntry<Types> | undefined,
   extension?: Extension
-): entry is Extension extends undefined
-  ? File<Types>
-  : Extension extends string
-    ? FileWithExtension<Types, Extension>
-    : FileWithExtension<Types, Extension[number]> {
+): entry is FileWithExtension<Types, Extension> {
   if (entry instanceof File) {
     const fileExtension = entry.getExtension()
 
@@ -2103,8 +2319,21 @@ export function isFile<
 }
 
 /** Determines if a `FileSystemEntry` is a `JavaScriptFile`. */
-export function isJavaScriptFile<Types extends Record<string, any>>(
-  entry: FileSystemEntry<Types> | undefined
-): entry is JavaScriptFile<Types> {
+export function isJavaScriptFile<
+  FileTypes extends Record<string, any>,
+  DirectoryTypes extends Record<string, any> = Record<string, any>,
+>(
+  entry: FileSystemEntry<DirectoryTypes> | undefined
+): entry is JavaScriptFile<FileTypes, DirectoryTypes> {
   return entry instanceof JavaScriptFile
+}
+
+/** Determines if a `FileSystemEntry` is an `MDXFile`. */
+export function isMDXFile<
+  FileTypes extends Record<string, any>,
+  DirectoryTypes extends Record<string, any> = Record<string, any>,
+>(
+  entry: FileSystemEntry<DirectoryTypes> | undefined
+): entry is MDXFile<FileTypes, DirectoryTypes> {
+  return entry instanceof MDXFile
 }

--- a/packages/renoun/src/utils/is-javascript-like-extension.ts
+++ b/packages/renoun/src/utils/is-javascript-like-extension.ts
@@ -11,8 +11,6 @@ export const javascriptLikeExtensions = [
   'mtsx',
   'cts',
   'ctsx',
-  'md',
-  'mdx',
 ] as const
 
 export type JavaScriptLikeExtensions = (typeof javascriptLikeExtensions)[number]

--- a/packages/renoun/vitest.config.ts
+++ b/packages/renoun/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vitest/config'
+import mdx from '@mdx-js/rollup'
+
+export default defineConfig({
+  plugins: [mdx()],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,6 +350,9 @@ importers:
         specifier: ^8.18.0
         version: 8.18.0
     devDependencies:
+      '@mdx-js/rollup':
+        specifier: ^3.1.0
+        version: 3.1.0(acorn@8.14.0)(rollup@4.32.1)
       '@types/react':
         specifier: 'catalog:'
         version: 19.0.10
@@ -898,6 +901,11 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@mdx-js/rollup@3.1.0':
+    resolution: {integrity: sha512-q4xOtUXpCzeouE8GaJ8StT4rDxm/U5j6lkMHL2srb2Q3Y7cobE0aXyPzXVVlbeIMBi+5R5MpbiaVE5/vJUdnHg==}
+    peerDependencies:
+      rollup: '>=2'
 
   '@next/env@15.1.7':
     resolution: {integrity: sha512-d9jnRrkuOH7Mhi+LHav2XW91HOgTAWHxjMPkXMGBc9B2b7614P7kjt8tAplRvJpbSt4nbO1lugcT/kAaWzjlLQ==}
@@ -3917,6 +3925,17 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.0.10
       react: 19.0.0
+
+  '@mdx-js/rollup@3.1.0(acorn@8.14.0)(rollup@4.32.1)':
+    dependencies:
+      '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
+      '@rollup/pluginutils': 5.1.4(rollup@4.32.1)
+      rollup: 4.32.1
+      source-map: 0.7.4
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - acorn
+      - supports-color
 
   '@next/env@15.1.7': {}
 


### PR DESCRIPTION
This adds `MDXFile`, `MDXFileExport`, and `isMDXFile` classes and utilities to better differentiate between specific MDX and JavaScript file methods. This also helps with performance since we should never attempt to analyze an MDX file using the TypeScript compiler and allows for future MDX-specific methods to be added.

### Breaking Changes

In some cases there may be breaking changes if you were loading mdx files and targeting `JavaScriptFile` related classes or types. These should be transitioned to the new `MDXFile`, `MDXFileExport`, and `isMDXFile` respectively.