### PR TITLE
parse frontmatter in mdx files

### DIFF
--- a/.changeset/fresh-cows-help.md
+++ b/.changeset/fresh-cows-help.md
@@ -1,0 +1,5 @@
+---
+'renoun': patch
+---
+
+Fixed build issue in the blog example

--- a/.changeset/fresh-cows-help.md
+++ b/.changeset/fresh-cows-help.md
@@ -2,4 +2,4 @@
 'renoun': patch
 ---
 
-Fixed build issue in the blog example
+* Extend `MDXFile.getRuntimeValue` to be able to parse the runtime values ( e.g. frontmatter ) based on the schema definition ( e.g. via `withSchema` )

--- a/examples/blog/app/[slug]/page.tsx
+++ b/examples/blog/app/[slug]/page.tsx
@@ -17,7 +17,7 @@ export default async function Page({
     month: '2-digit',
     day: '2-digit',
     timeZone: 'UTC',
-  }).format(new Date(frontmatter.date))
+  }).format(frontmatter.date)
   const Content = await post.getExportValue('default')
 
   return (

--- a/examples/blog/app/[slug]/page.tsx
+++ b/examples/blog/app/[slug]/page.tsx
@@ -17,7 +17,7 @@ export default async function Page({
     month: '2-digit',
     day: '2-digit',
     timeZone: 'UTC',
-  }).format(frontmatter.date)
+  }).format(new Date(frontmatter.date))
   const Content = await post.getExportValue('default')
 
   return (


### PR DESCRIPTION
With the latest changes in renoun 8.7.0 and providing the `MDXFile` class, we had some problems in the CI to build the blog example app.

After analyzing the code, it seems that the rootcause is/was the missing parse logic inside the `MDXFile` class.

This PR adds the missing methods.

Maybe we could use a generic parse method to have the same behaviour for `JavaScriptFile` and `MDXFile`, but for now, I just copied the code and updated the error message to show the correct class name.