### PR TITLE
allow CodeBlock to target local files

### DIFF
--- a/.changeset/real-guests-say.md
+++ b/.changeset/real-guests-say.md
@@ -1,0 +1,5 @@
+---
+'renoun': minor
+---
+
+Adds back the `workingDirectory` prop to the `CodeBlock` component for targeting local files. When defined, this will be joined with the `path` prop to load a source file located within the file system instead of creating a virtual file which allows imports and types to be resolved correctly.

--- a/packages/renoun/src/components/CodeBlock/Context.tsx
+++ b/packages/renoun/src/components/CodeBlock/Context.tsx
@@ -1,19 +1,27 @@
 import type { CSSProperties } from 'react'
 
+import { createContext, getContext } from '../../utils/context.js'
 import type { Languages } from '../../utils/get-language.js'
-import { createContext } from '../../utils/context.js'
 
 /** @internal */
 export type ContextValue = {
-  value: string
-  language: Languages
-  filePath: string
+  value?: string
+  language?: Languages
+  filePath?: string
   label?: string
   allowErrors?: boolean | string
   showErrors?: boolean
   shouldAnalyze?: boolean
+  shouldFormat?: boolean
   highlightedLines?: string
   padding?: CSSProperties['padding']
+  workingDirectory?: string
+  resolved?: {
+    value: string
+    language: Languages
+    filePath: string
+    label: string
+  }
   resolvers: PromiseWithResolvers<void>
 } | null
 
@@ -22,3 +30,34 @@ export type ContextValue = {
  * @internal
  */
 export const Context = createContext<ContextValue>(null)
+
+/**
+ * Resolved context value.
+ * @internal
+ */
+export async function getResolvedContext() {
+  const context = getContext(Context)
+
+  if (context === null) {
+    throw new Error(
+      '[renoun] `getResolvedContext` must be used inside a `CodeBlock` component that specifies `Tokens`.'
+    )
+  }
+
+  await context.resolvers.promise
+
+  const {
+    resolvers,
+    resolved,
+    value,
+    language,
+    filePath,
+    label,
+    ...restContext
+  } = context
+
+  return {
+    ...resolved!,
+    ...restContext,
+  }
+}

--- a/packages/renoun/src/components/CodeBlock/CopyButton.tsx
+++ b/packages/renoun/src/components/CodeBlock/CopyButton.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
 
-import { getContext } from '../../utils/context'
-import { Context } from './Context'
+import { getResolvedContext } from './Context'
 import { CopyButtonClient } from './CopyButtonClient'
 
 export async function CopyButton(
   props: React.ComponentProps<typeof CopyButtonClient>
 ) {
-  const context = getContext(Context)
+  let value = props.value
 
-  if (context) {
-    await context.resolvers.promise
+  if (value === undefined) {
+    const context = await getResolvedContext()
+    value = context.value
   }
 
-  return <CopyButtonClient {...props} value={props.value ?? context?.value} />
+  return <CopyButtonClient {...props} value={value} />
 }

--- a/packages/renoun/src/components/CodeBlock/CopyButtonClient.tsx
+++ b/packages/renoun/src/components/CodeBlock/CopyButtonClient.tsx
@@ -2,7 +2,6 @@
 import React, { use, useState } from 'react'
 import { css, type CSSObject } from 'restyle'
 
-import { CopyButtonContext } from './contexts.js'
 import { PreActiveContext } from './Pre.js'
 
 /**
@@ -10,7 +9,7 @@ import { PreActiveContext } from './Pre.js'
  * @internal
  */
 export function CopyButtonClient({
-  value: valueProp,
+  value,
   css: cssProp,
   className,
   ...props
@@ -20,9 +19,6 @@ export function CopyButtonClient({
     | ((event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => string)
   css?: CSSObject
 } & Omit<React.ComponentProps<'button'>, 'value'>) {
-  const contextValue = use(CopyButtonContext)
-  const value = valueProp || contextValue
-
   if (!value) {
     throw new Error(
       '[renoun] The calculated value for the `CopyButton` component was `undefined` or an empty string. Use the `value` prop or use the `CopyButton` component within a `CodeBlock` component.'

--- a/packages/renoun/src/components/CodeBlock/LineNumbers.tsx
+++ b/packages/renoun/src/components/CodeBlock/LineNumbers.tsx
@@ -2,8 +2,7 @@ import React, { Fragment } from 'react'
 import { styled, type CSSObject } from 'restyle'
 
 import { getThemeColors } from '../../utils/get-theme.js'
-import { getContext } from '../../utils/context.js'
-import { Context } from './Context.js'
+import { getResolvedContext } from './Context.js'
 
 export interface LineNumbersProps {
   /** A string of comma separated lines and ranges to highlight. */
@@ -19,26 +18,14 @@ export interface LineNumbersProps {
   style?: React.CSSProperties
 }
 
-async function LineNumbersAsync({
+/** Renders line numbers for the `CodeBlock` component. */
+export async function LineNumbers({
   highlightRanges: highlightRangesProp,
   css,
   className,
   style,
 }: LineNumbersProps) {
-  const context = getContext(Context)
-
-  if (context) {
-    await context.resolvers.promise
-  }
-
-  const value = context?.value
-
-  if (!value) {
-    throw new Error(
-      '[renoun] `LineNumbers` must be used inside a `CodeBlock` component that specifies `Tokens`.'
-    )
-  }
-
+  const context = await getResolvedContext()
   const theme = await getThemeColors()
   const highlightRanges = highlightRangesProp || context?.highlightedLines
   const shouldHighlightLine = calculateLinesToHighlight(highlightRanges)
@@ -49,7 +36,7 @@ async function LineNumbersAsync({
       className={className}
       style={style}
     >
-      {value.split('\n').map((_: any, lineIndex: number) => {
+      {context.value.split('\n').map((_: any, lineIndex: number) => {
         const shouldHighlight = shouldHighlightLine(lineIndex)
         const content = shouldHighlight ? (
           <Highlighted css={{ color: theme.editorLineNumber.activeForeground }}>
@@ -68,11 +55,6 @@ async function LineNumbersAsync({
       })}
     </Container>
   )
-}
-
-/** Renders line numbers for the `CodeBlock` component. */
-export function LineNumbers(props: LineNumbersProps) {
-  return <LineNumbersAsync {...props} />
 }
 
 const Container = styled('span', {

--- a/packages/renoun/src/components/CodeBlock/Toolbar.tsx
+++ b/packages/renoun/src/components/CodeBlock/Toolbar.tsx
@@ -2,14 +2,10 @@ import React from 'react'
 import { styled, type CSSObject } from 'restyle'
 
 import { getThemeColors } from '../../utils/get-theme.js'
-import { getContext } from '../../utils/context.js'
+import { getResolvedContext } from './Context.js'
 import { CopyButton } from './CopyButton.js'
-import { Context } from './Context.js'
 
 export interface ToolbarProps {
-  /** The value of the code block. */
-  value?: string
-
   /** Whether or not to allow copying the code block value. Accepts a boolean or a string that will be copied. */
   allowCopy?: boolean | string
 
@@ -27,19 +23,17 @@ export interface ToolbarProps {
 }
 
 async function ToolbarAsync({
-  value: valueProp,
   allowCopy,
   css,
   className,
   style,
   children,
 }: ToolbarProps) {
-  const context = getContext(Context)
+  const context = await getResolvedContext()
   const theme = await getThemeColors()
-  const value = valueProp ?? context?.value
   let childrenToRender = children
 
-  if (childrenToRender === undefined && context) {
+  if (childrenToRender === undefined) {
     childrenToRender = <Label>{context.label}</Label>
   }
 
@@ -51,9 +45,9 @@ async function ToolbarAsync({
     >
       {childrenToRender}
 
-      {allowCopy && value ? (
+      {allowCopy ? (
         <CopyButton
-          value={typeof allowCopy === 'string' ? allowCopy : value}
+          value={typeof allowCopy === 'string' ? allowCopy : context.value}
           css={{
             padding: 0,
             marginLeft: 'auto',

--- a/packages/renoun/src/components/CodeBlock/examples/index.tsx
+++ b/packages/renoun/src/components/CodeBlock/examples/index.tsx
@@ -79,7 +79,7 @@ export async function CustomStyles() {
   )
 
   return (
-    <CodeBlock path="toolbar.tsx">
+    <CodeBlock path="./counter/Counter.tsx" workingDirectory={directoryPath}>
       <div
         style={{
           fontSize: '1rem',


### PR DESCRIPTION
This adds back the `workingDirectory` prop to the `CodeBlock` component for targeting local files. When defined, this will be joined with the `path` prop to load a source file located within the file system instead of creating a virtual file which allows imports and types to be resolved correctly.

```tsx
import { dirname, join } from 'node:path'
import { fileURLToPath } from 'node:url'
import { readFile } from 'node:fs/promises'

const directoryPath = dirname(fileURLToPath(import.meta.url))

export default async function App() {
  const code = await readFile(
    join(directoryPath, './counter/Counter.tsx'),
    'utf-8'
  )
  return (
    <CodeBlock path="./counter/Counter.tsx" workingDirectory={directoryPath}>
      {code}
    </CodeBlock>
  )
}
```