### PR TITLE
jsx headings

### DIFF
--- a/.changeset/loud-pans-poke.md
+++ b/.changeset/loud-pans-poke.md
@@ -1,0 +1,10 @@
+---
+'renoun': minor
+'@renoun/mdx': minor
+---
+
+Updates exported `headings` variable from the `addHeadings` remark plugin to include a new `children` property to allow rendering the JSX children of the heading element. This allows for more complex headings to be rendered with the `addHeadings` plugin. For example, headings with inline code or links.
+
+### Breaking Changes
+
+The `depth` property of the heading metadata object was renamed to `level` to better reflect HTML nomenclature.

--- a/.changeset/loud-pans-poke.md
+++ b/.changeset/loud-pans-poke.md
@@ -3,7 +3,32 @@
 '@renoun/mdx': minor
 ---
 
-Updates exported `headings` variable from the `addHeadings` remark plugin to include a new `children` property to allow rendering the JSX children of the heading element. This allows for more complex headings to be rendered with the `addHeadings` plugin. For example, headings with inline code or links.
+Updates exported `headings` variable from the `addHeadings` remark plugin to include a new `children` property to allow rendering the JSX children of the heading element.
+
+For example, headings with inline code or links:
+
+```mdx
+# Heading with `code`
+```
+
+Roughly yields:
+
+```mdx
+export const headings = [
+  {
+    level: 1,
+    id: 'heading-with-code',
+    text: 'Heading with code',
+    children: (
+      <>
+        Heading with <code>code</code>
+      </>
+    ),
+  },
+]
+
+# Heading with `code`
+```
 
 ### Breaking Changes
 

--- a/apps/site/app/(site)/components/[...slug]/page.tsx
+++ b/apps/site/app/(site)/components/[...slug]/page.tsx
@@ -96,21 +96,23 @@ export default async function Component({
   let headings: MDXHeadings = []
 
   if (mdxHeadings) {
-    headings.push(...mdxHeadings)
+    headings.push(...(mdxHeadings as MDXHeadings))
   }
 
   if (examplesExports.length) {
     const parsedExports = examplesExports.map((exampleExport) => ({
+      level: 3,
       id: exampleExport.getSlug(),
+      children: exampleExport.getTitle(),
       text: exampleExport.getTitle(),
-      depth: 3,
     }))
 
     headings.push(
       {
+        level: 2,
         id: 'examples',
+        children: 'Examples',
         text: 'Examples',
-        depth: 2,
       },
       ...parsedExports
     )
@@ -119,14 +121,16 @@ export default async function Component({
   if (componentExports) {
     headings.push(
       {
+        level: 2,
         id: 'api-reference',
+        children: 'API Reference',
         text: 'API Reference',
-        depth: 2,
       },
       ...componentExports.map((componentExport) => ({
+        level: 3,
         id: componentExport.getSlug(),
+        children: componentExport.getName(),
         text: componentExport.getName(),
-        depth: 3,
       }))
     )
   }

--- a/apps/site/collections/renoun.ts
+++ b/apps/site/collections/renoun.ts
@@ -58,8 +58,9 @@ export const ComponentsCollection = new Directory({
         headings: z.array(
           z.object({
             id: z.string(),
+            level: z.number(),
+            children: z.custom<NonNullable<React.ReactNode>>(),
             text: z.string(),
-            depth: z.number(),
           })
         ),
         metadata: z.object({

--- a/apps/site/collections/site.ts
+++ b/apps/site/collections/site.ts
@@ -5,8 +5,9 @@ const mdxSchema = {
   headings: z.array(
     z.object({
       id: z.string(),
+      level: z.number(),
+      children: z.custom<NonNullable<React.ReactNode>>(),
       text: z.string(),
-      depth: z.number(),
     })
   ),
   metadata: z.object({

--- a/apps/site/components/TableOfContents.tsx
+++ b/apps/site/components/TableOfContents.tsx
@@ -58,16 +58,16 @@ export function TableOfContents({
           <li css={{ marginBottom: '1rem' }}>
             <h4 className="title">On this page</h4>
           </li>
-          {headings?.map(({ text, depth, id }, index) =>
-            depth > 1 ? (
+          {headings?.map(({ id, level, text, children }) =>
+            level > 1 ? (
               <li key={id} css={{ display: 'flex' }}>
                 <Link
                   id={id}
                   sectionObserver={sectionObserver}
-                  css={{ paddingLeft: (depth - 2) * 0.8 + 'rem' }}
+                  css={{ paddingLeft: (level - 2) * 0.8 + 'rem' }}
                   title={text}
                 >
-                  {text}
+                  {children}
                 </Link>
               </li>
             ) : null

--- a/apps/site/mdx.d.ts
+++ b/apps/site/mdx.d.ts
@@ -1,7 +1,8 @@
 declare module '*.mdx' {
   export const headings: {
     id: any
+    level: number
+    children: React.ReactNode
     text: string
-    depth: number
   }[]
 }

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -27,7 +27,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "prepare": "pnpm run build"
+    "prepare": "pnpm run build",
+    "test": "vitest --typecheck"
   },
   "exports": {
     ".": {
@@ -73,12 +74,14 @@
     }
   },
   "devDependencies": {
+    "@types/react": "catalog:",
     "@types/mdast": "^4.0.4",
     "@types/hast": "^3.0.4",
     "@types/unist": "^3.0.3",
     "vfile": "^6.0.3"
   },
   "dependencies": {
+    "@mdx-js/mdx": "^3.1.0",
     "@types/mdx": "catalog:",
     "estree-util-value-to-estree": "^3.3.2",
     "mdast-util-mdx": "^3.0.0",

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -74,14 +74,14 @@
     }
   },
   "devDependencies": {
-    "@types/react": "catalog:",
-    "@types/mdast": "^4.0.4",
+    "@mdx-js/mdx": "^3.1.0",
     "@types/hast": "^3.0.4",
+    "@types/mdast": "^4.0.4",
+    "@types/react": "catalog:",
     "@types/unist": "^3.0.3",
     "vfile": "^6.0.3"
   },
   "dependencies": {
-    "@mdx-js/mdx": "^3.1.0",
     "@types/mdx": "catalog:",
     "estree-util-value-to-estree": "^3.3.2",
     "mdast-util-mdx": "^3.0.0",

--- a/packages/mdx/src/remark/add-headings.test.ts
+++ b/packages/mdx/src/remark/add-headings.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from 'vitest'
+import { compile } from '@mdx-js/mdx'
+
+import addHeadings from './add-headings'
+
+describe('addHeadings', () => {
+  test('string heading', async () => {
+    const result = await compile(`# Hello, world!`, {
+      remarkPlugins: [addHeadings],
+    })
+
+    expect(String(result)).toMatchInlineSnapshot(`
+      "import {jsx as _jsx} from "react/jsx-runtime";
+      export const headings = [{
+        id: "hello,-world!",
+        level: 1,
+        children: "Hello, world!",
+        text: "Hello, world!"
+      }];
+      function _createMdxContent(props) {
+        const _components = {
+          h1: "h1",
+          ...props.components
+        };
+        return _jsx(_components.h1, {
+          id: "hello,-world!",
+          children: "Hello, world!"
+        });
+      }
+      export default function MDXContent(props = {}) {
+        const {wrapper: MDXLayout} = props.components || ({});
+        return MDXLayout ? _jsx(MDXLayout, {
+          ...props,
+          children: _jsx(_createMdxContent, {
+            ...props
+          })
+        }) : _createMdxContent(props);
+      }
+      "
+    `)
+  })
+
+  test('code heading', async () => {
+    const result = await compile(`# Hello, \`world\`!`, {
+      remarkPlugins: [addHeadings],
+    })
+
+    expect(String(result)).toMatchInlineSnapshot(`
+      "import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
+      export const headings = [{
+        id: "hello,-world!",
+        level: 1,
+        children: _jsxs(_Fragment, {
+          children: ["Hello, ", _jsx("code", {
+            children: "world"
+          }), "!"]
+        }),
+        text: "Hello, world!"
+      }];
+      function _createMdxContent(props) {
+        const _components = {
+          code: "code",
+          h1: "h1",
+          ...props.components
+        };
+        return _jsxs(_components.h1, {
+          id: "hello,-world!",
+          children: ["Hello, ", _jsx(_components.code, {
+            children: "world"
+          }), "!"]
+        });
+      }
+      export default function MDXContent(props = {}) {
+        const {wrapper: MDXLayout} = props.components || ({});
+        return MDXLayout ? _jsx(MDXLayout, {
+          ...props,
+          children: _jsx(_createMdxContent, {
+            ...props
+          })
+        }) : _createMdxContent(props);
+      }
+      "
+    `)
+  })
+
+  test('link heading', async () => {
+    const result = await compile(`# [Hello, world!](https://example.com)`, {
+      remarkPlugins: [addHeadings],
+    })
+
+    expect(String(result)).toMatchInlineSnapshot(`
+      "import {Fragment as _Fragment, jsx as _jsx} from "react/jsx-runtime";
+      export const headings = [{
+        id: "hello,-world!",
+        level: 1,
+        children: _jsx(_Fragment, {
+          children: _jsx("a", {
+            href: "https://example.com",
+            children: "Hello, world!"
+          })
+        }),
+        text: "Hello, world!"
+      }];
+      function _createMdxContent(props) {
+        const _components = {
+          a: "a",
+          h1: "h1",
+          ...props.components
+        };
+        return _jsx(_components.h1, {
+          id: "hello,-world!",
+          children: _jsx(_components.a, {
+            href: "https://example.com",
+            children: "Hello, world!"
+          })
+        });
+      }
+      export default function MDXContent(props = {}) {
+        const {wrapper: MDXLayout} = props.components || ({});
+        return MDXLayout ? _jsx(MDXLayout, {
+          ...props,
+          children: _jsx(_createMdxContent, {
+            ...props
+          })
+        }) : _createMdxContent(props);
+      }
+      "
+    `)
+  })
+
+  test('image heading', async () => {
+    const result = await compile(
+      `# ![Hello, world!](https://example.com/image.png)`,
+      {
+        remarkPlugins: [addHeadings],
+      }
+    )
+
+    expect(String(result)).toMatchInlineSnapshot(`
+      "import {Fragment as _Fragment, jsx as _jsx} from "react/jsx-runtime";
+      export const headings = [{
+        id: "hello,-world!",
+        level: 1,
+        children: _jsx(_Fragment, {
+          children: _jsx("img", {
+            src: "https://example.com/image.png",
+            alt: "Hello, world!"
+          })
+        }),
+        text: "Hello, world!"
+      }];
+      function _createMdxContent(props) {
+        const _components = {
+          h1: "h1",
+          img: "img",
+          ...props.components
+        };
+        return _jsx(_components.h1, {
+          id: "hello,-world!",
+          children: _jsx(_components.img, {
+            src: "https://example.com/image.png",
+            alt: "Hello, world!"
+          })
+        });
+      }
+      export default function MDXContent(props = {}) {
+        const {wrapper: MDXLayout} = props.components || ({});
+        return MDXLayout ? _jsx(MDXLayout, {
+          ...props,
+          children: _jsx(_createMdxContent, {
+            ...props
+          })
+        }) : _createMdxContent(props);
+      }
+      "
+    `)
+  })
+})

--- a/packages/mdx/src/remark/add-headings.ts
+++ b/packages/mdx/src/remark/add-headings.ts
@@ -1,10 +1,9 @@
-import 'mdast-util-mdx'
 import type { Root, Heading } from 'mdast'
 import type { VFile } from 'vfile'
-import { valueToEstree } from 'estree-util-value-to-estree'
 import { define } from 'unist-util-mdx-define'
-import { toString } from 'mdast-util-to-string'
 import { visit } from 'unist-util-visit'
+import { toString } from 'mdast-util-to-string'
+import 'mdast-util-mdx'
 
 declare module 'mdast' {
   interface Data {
@@ -14,49 +13,237 @@ declare module 'mdast' {
 
 /** An array of headings metadata. */
 export type MDXHeadings = {
-  id: any
+  /** The slugified heading text. */
+  id: string
+
+  /** The heading level. */
+  level: number
+
+  /** The stringified heading text. */
   text: string
-  depth: number
+
+  /** The heading JSX children. */
+  children?: React.ReactNode
 }[]
 
-/** Adds an `id` to all headings and exports a `headings` prop. */
+/** Exports a `headings` variable containing an array of headings metadata. */
 export default function addHeadings() {
   return function (tree: Root, file: VFile) {
-    const headings: MDXHeadings = []
-    const headingCounts = new Map()
+    const headingsArray: any[] = []
+    const headingCounts = new Map<string, number>()
 
     visit(tree, 'heading', (node: Heading) => {
-      const text = node.children.map((child) => toString(child)).join('')
-      let id = createSlug(text)
+      const text = toString(node)
+      let slug = createSlug(text)
 
-      if (headingCounts.has(id)) {
-        const count = headingCounts.get(id) + 1
-        headingCounts.set(id, count)
-        id = `${id}-${count}`
+      // Ensure unique slugs.
+      if (headingCounts.has(slug)) {
+        const count = headingCounts.get(slug)! + 1
+        headingCounts.set(slug, count)
+        slug = `${slug}-${count}`
       } else {
-        headingCounts.set(id, 1)
+        headingCounts.set(slug, 1)
       }
 
-      const heading = {
-        text,
-        id,
-        depth: node.depth,
-      }
-      headings.push(heading)
+      headingsArray.push({
+        type: 'ObjectExpression',
+        properties: [
+          {
+            type: 'Property',
+            key: { type: 'Identifier', name: 'id' },
+            value: { type: 'Literal', value: slug },
+            kind: 'init',
+          },
+          {
+            type: 'Property',
+            key: { type: 'Identifier', name: 'level' },
+            value: { type: 'Literal', value: node.depth },
+            kind: 'init',
+          },
+          {
+            type: 'Property',
+            key: { type: 'Identifier', name: 'children' },
+            value: mdastNodesToJsxFragment(node.children),
+            kind: 'init',
+          },
+          {
+            type: 'Property',
+            key: { type: 'Identifier', name: 'text' },
+            value: { type: 'Literal', value: text },
+            kind: 'init',
+          },
+        ],
+      })
 
-      /* Add `id` to heading. */
-      if (!node.data) {
-        node.data = {}
-      }
-      if (!node.data.hProperties) {
-        node.data.hProperties = {}
-      }
-      node.data.hProperties.id = heading.id
+      // Also add an id for HTML output.
+      node.data ??= {}
+      node.data.hProperties ??= {}
+      node.data.hProperties.id = slug
     })
 
     define(tree, file, {
-      headings: valueToEstree(headings),
+      headings: {
+        type: 'ArrayExpression',
+        elements: headingsArray,
+      },
     })
+  }
+}
+
+/** Convert an array of mdast nodes into a text node or JSX fragment. */
+function mdastNodesToJsxFragment(nodes: any[]) {
+  const jsxChildren = nodes.map(mdastNodeToJsxChild)
+
+  if (jsxChildren.length === 1) {
+    const child = jsxChildren[0]
+
+    if (child.type === 'JSXText') {
+      return { type: 'Literal', value: child.value }
+    }
+  }
+
+  return {
+    type: 'JSXFragment',
+    openingFragment: {
+      type: 'JSXOpeningFragment',
+      attributes: [],
+      selfClosing: false,
+    },
+    closingFragment: {
+      type: 'JSXClosingFragment',
+    },
+    children: jsxChildren,
+  }
+}
+
+/**
+ * Convert an mdast inline node into its corresponding ESTree JSX AST node.
+ * This function covers:
+ *
+ * - text
+ * - strong, emphasis, delete, inlineCode
+ * - break (line break)
+ * - link, image
+ */
+function mdastNodeToJsxChild(node: any) {
+  switch (node.type) {
+    case 'text':
+      return { type: 'JSXText', value: node.value }
+
+    case 'strong':
+      return makeJsxElement('strong', node.children)
+
+    case 'emphasis':
+      return makeJsxElement('em', node.children)
+
+    case 'inlineCode':
+      return makeJsxElement('code', [{ type: 'JSXText', value: node.value }])
+
+    case 'delete':
+      return makeJsxElement('del', node.children)
+
+    case 'break':
+      return {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: { type: 'JSXIdentifier', name: 'br' },
+          attributes: [],
+          selfClosing: true,
+        },
+        closingElement: null,
+        children: [],
+      }
+
+    case 'link': {
+      const attributes = [
+        {
+          type: 'JSXAttribute',
+          name: { type: 'JSXIdentifier', name: 'href' },
+          value: { type: 'Literal', value: node.url },
+        },
+      ]
+      if (node.title) {
+        attributes.push({
+          type: 'JSXAttribute',
+          name: { type: 'JSXIdentifier', name: 'title' },
+          value: { type: 'Literal', value: node.title },
+        })
+      }
+      return {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: { type: 'JSXIdentifier', name: 'a' },
+          attributes,
+          selfClosing: false,
+        },
+        closingElement: {
+          type: 'JSXClosingElement',
+          name: { type: 'JSXIdentifier', name: 'a' },
+        },
+        children: node.children.map(mdastNodeToJsxChild),
+      }
+    }
+
+    case 'image': {
+      const attributes = [
+        {
+          type: 'JSXAttribute',
+          name: { type: 'JSXIdentifier', name: 'src' },
+          value: { type: 'Literal', value: node.url },
+        },
+      ]
+      if (node.alt) {
+        attributes.push({
+          type: 'JSXAttribute',
+          name: { type: 'JSXIdentifier', name: 'alt' },
+          value: { type: 'Literal', value: node.alt },
+        })
+      }
+      if (node.title) {
+        attributes.push({
+          type: 'JSXAttribute',
+          name: { type: 'JSXIdentifier', name: 'title' },
+          value: { type: 'Literal', value: node.title },
+        })
+      }
+      return {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: { type: 'JSXIdentifier', name: 'img' },
+          attributes,
+          selfClosing: true,
+        },
+        closingElement: null,
+        children: [],
+      }
+    }
+
+    default:
+      return { type: 'JSXText', value: toString(node) }
+  }
+}
+
+/**
+ * Helper to create a simple JSXElement.
+ * It builds an element like <tagName>{...children}</tagName>.
+ */
+function makeJsxElement(tagName: string, mdastChildren: any[]): any {
+  return {
+    type: 'JSXElement',
+    openingElement: {
+      type: 'JSXOpeningElement',
+      name: { type: 'JSXIdentifier', name: tagName },
+      attributes: [],
+      selfClosing: false,
+    },
+    closingElement: {
+      type: 'JSXClosingElement',
+      name: { type: 'JSXIdentifier', name: tagName },
+    },
+    children: mdastChildren.map(mdastNodeToJsxChild),
   }
 }
 

--- a/packages/renoun/src/file-system/index.test.ts
+++ b/packages/renoun/src/file-system/index.test.ts
@@ -1589,8 +1589,9 @@ describe('file system', () => {
             headings: z.array(
               z.object({
                 id: z.string(),
+                level: z.number(),
                 text: z.string(),
-                depth: z.number(),
+                children: z.custom<React.ReactNode>(),
               })
             ),
             metadata: z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
 
   packages/mdx:
     dependencies:
+      '@mdx-js/mdx':
+        specifier: ^3.1.0
+        version: 3.1.0(acorn@8.14.0)
       '@types/mdx':
         specifier: 'catalog:'
         version: 2.0.13
@@ -277,6 +280,9 @@ importers:
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.12
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,9 +234,6 @@ importers:
 
   packages/mdx:
     dependencies:
-      '@mdx-js/mdx':
-        specifier: ^3.1.0
-        version: 3.1.0(acorn@8.14.0)
       '@types/mdx':
         specifier: 'catalog:'
         version: 2.0.13
@@ -274,6 +271,9 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
     devDependencies:
+      '@mdx-js/mdx':
+        specifier: ^3.1.0
+        version: 3.1.0(acorn@8.14.0)
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4


### PR DESCRIPTION

Updates exported `headings` variable from the `addHeadings` remark plugin to include a new `children` property to allow rendering the JSX children of the heading element.

For example, headings with inline code or links:

```mdx
# Heading with `code`
```

Roughly yields:

```mdx
export const headings = [
  {
    level: 1,
    id: 'heading-with-code',
    text: 'Heading with code',
    children: (
      <>
        Heading with <code>code</code>
      </>
    ),
  },
]

# Heading with `code`
```

### Breaking Changes

The `depth` property of the heading metadata object was renamed to `level` to better reflect HTML nomenclature.
