### PR TITLE
rename MDXRenderer -> MDX

### DIFF
--- a/.changeset/good-clocks-press.md
+++ b/.changeset/good-clocks-press.md
@@ -1,0 +1,9 @@
+---
+'renoun': major
+---
+
+Renames the `MDXRenderer` component to `MDX`. This is to better align with the new `Markdown` component.
+
+### Breaking Changes
+
+- Rename any `MDXRenderer` component references imported from `renoun/components` to `MDX`.

--- a/.changeset/some-squids-kick.md
+++ b/.changeset/some-squids-kick.md
@@ -2,4 +2,4 @@
 'renoun': patch
 ---
 
-Improves `MDXRenderer` compiler error message to show line and column of each error.
+Improves `MDX` component compiler error message to show line and column of each error.

--- a/apps/site/app/(site)/components/[...slug]/page.tsx
+++ b/apps/site/app/(site)/components/[...slug]/page.tsx
@@ -11,7 +11,7 @@ import type { MDXHeadings } from 'renoun/mdx'
 import { GeistMono } from 'geist/font/mono'
 
 import { CollectionGroup, ComponentsCollection } from '@/collections'
-import { MDXRenderer } from '@/components/MDXRenderer'
+import { MDX } from '@/components/MDX'
 import { SiblingLink } from '@/components/SiblingLink'
 import { TableOfContents } from '@/components/TableOfContents'
 
@@ -152,7 +152,7 @@ export default async function Component({
               <h1 css={{ fontSize: '3rem', margin: 0 }}>
                 {title} {isExamplesPage ? 'Examples' : ''}
               </h1>
-              {description ? <MDXRenderer>{description}</MDXRenderer> : null}
+              {description ? <MDX>{description}</MDX> : null}
               {Content ? <Content /> : null}
             </div>
           ) : (

--- a/apps/site/components/MDX.tsx
+++ b/apps/site/components/MDX.tsx
@@ -1,11 +1,11 @@
-import { MDXRenderer as BaseMDXRenderer } from 'renoun/components'
+import { MDX as DefaultMDX } from 'renoun/components'
 import { remarkPlugins, rehypePlugins } from 'renoun/mdx'
 
 import { MDXComponents } from '@/components/MDXComponents'
 
-export function MDXRenderer({ children }: { children: string }) {
+export function MDX({ children }: { children: string }) {
   return (
-    <BaseMDXRenderer
+    <DefaultMDX
       components={MDXComponents}
       remarkPlugins={remarkPlugins}
       rehypePlugins={rehypePlugins}

--- a/apps/site/guides/01.mdx.mdx
+++ b/apps/site/guides/01.mdx.mdx
@@ -9,12 +9,12 @@ This guide will help you understand how to use MDX with renoun.
 
 [MDX](https://mdxjs.com/) is a format that allows you to write JSX directly within Markdown documents. This lets you embed React components and JSX elements inside your Markdown files, creating interactive and dynamic content. MDX works seamlessly with renoun, making it a powerful tool for your documentation needs.
 
-## `MDXRenderer` component
+## `MDX` component
 
-The easiest way to get started using MDX with renoun is with the `MDXRenderer` component:
+The easiest way to get started using MDX with renoun is with the `MDX` component:
 
 ```tsx
-import { MDXRenderer } from 'renoun/components'
+import { MDX } from 'renoun/components'
 
 const content = `
 # Hello, world!
@@ -23,11 +23,11 @@ This is an MDX file.
 `
 
 export default function Page() {
-  return <MDXRenderer>{content}</MDXRenderer>
+  return <MDX>{content}</MDX>
 }
 ```
 
-In this example, the `MDXRenderer` component renders a string of MDX content within your React components. It parses the MDX and converts it into React components that can be rendered in your application.
+In this example, the `MDX` component renders a string of MDX content within your React components. It parses the MDX and converts it into React components that can be rendered in your application.
 
 ## MDX with Next.js
 
@@ -125,12 +125,12 @@ Exports the reading time metadata added by `rehype-infer-reading-time-meta` as a
 
 ## Applying plugins
 
-After installing the package, you can import and apply the plugins to the `MDXRenderer` component or any other MDX configuration in your application.
+After installing the package, you can import and apply plugins to the `MDX` component or any other MDX configuration in your application.
 
-We'll use the example from before and add the `renoun/mdx` plugins to the `MDXRenderer` component:
+We'll use the example from before and add the `renoun/mdx` plugins to the `MDX` component:
 
 ```tsx
-import { MDXRenderer } from 'renoun/components'
+import { MDX } from 'renoun/components'
 import { remarkPlugins, rehypePlugins } from 'renoun/mdx'
 
 const content = `
@@ -145,9 +145,9 @@ This is an MDX file.
 
 export default function Page() {
   return (
-    <MDXRenderer remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
+    <MDX remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
       {content}
-    </MDXRenderer>
+    </MDX>
   )
 }
 ```
@@ -156,4 +156,4 @@ Now we can utilize plugins like [remark-frontmatter](#remark-frontmatter) to spe
 
 ## Conclusion
 
-MDX is a powerful tool that can be used to create interactive and dynamic content in your documentation. By using the `MDXRenderer` component and custom plugins, you can easily render MDX content in your components and extend the functionality of the MDX rendering process.
+MDX is a powerful tool that can be used to create interactive and dynamic content in your documentation. By using the `MDX` component and custom plugins, you can easily render MDX content in your components and extend the functionality of the MDX rendering process.

--- a/packages/renoun/README.md
+++ b/packages/renoun/README.md
@@ -55,7 +55,7 @@ Built from the ground up for React, renoun gives you the full power of compositi
 
 #### Drop‑In Components
 
-Quickly get started with powerful components like [`APIReference`](https://www.renoun.dev/components/api-reference), [`CodeBlock`](https://www.renoun.dev/components/code-block), [`MDXRenderer`](https://www.renoun.dev/components/mdx-renderer), and more — no extra setup required.
+Quickly get started with powerful components like [`APIReference`](https://www.renoun.dev/components/api-reference), [`CodeBlock`](https://www.renoun.dev/components/code-block), [`MDX`](https://www.renoun.dev/components/mdx), and more — no extra setup required.
 
 [Explore components →](https://www.renoun.dev/components)
 

--- a/packages/renoun/src/components/APIReference.tsx
+++ b/packages/renoun/src/components/APIReference.tsx
@@ -19,14 +19,14 @@ import type {
 import { isParameterType, isPropertyType } from '../utils/resolve-type.js'
 import { CodeBlock, parsePreProps } from './CodeBlock/index.js'
 import { CodeInline } from './CodeInline.js'
-import { MDXRenderer } from './MDXRenderer.js'
-import type { MDXRendererProps } from './MDXRenderer.js'
+import { MDX } from './MDX.js'
+import type { MDXProps } from './MDX.js'
 
 const codeInlineStyles = {
   display: 'inline-block',
   whiteSpace: 'nowrap',
 } satisfies CSSObject
-const mdxRendererProps = {
+const mdxProps = {
   components: {
     pre: (props) => {
       return <CodeBlock {...parsePreProps(props)} shouldAnalyze={false} />
@@ -45,7 +45,7 @@ const mdxRendererProps = {
   },
   rehypePlugins,
   remarkPlugins,
-} satisfies Omit<MDXRendererProps, 'children'>
+} satisfies Omit<MDXProps, 'children'>
 
 interface SourceString {
   /** The file path to the source code. */
@@ -151,7 +151,7 @@ async function APIReferenceAsync({
             </div>
 
             {type.description ? (
-              <MDXRenderer children={type.description} {...mdxRendererProps} />
+              <MDX children={type.description} {...mdxProps} />
             ) : null}
           </div>
 
@@ -212,7 +212,7 @@ async function APIReferenceAsync({
         {type.description &&
         type.kind !== 'Function' &&
         type.kind !== 'Component' ? (
-          <MDXRenderer children={type.description} {...mdxRendererProps} />
+          <MDX children={type.description} {...mdxProps} />
         ) : null}
       </div>
 
@@ -330,10 +330,7 @@ function TypeChildren({
                 }}
               />
               {signature.description ? (
-                <MDXRenderer
-                  children={signature.description}
-                  {...mdxRendererProps}
-                />
+                <MDX children={signature.description} {...mdxProps} />
               ) : null}
               {signature.parameter ? (
                 <div>
@@ -393,10 +390,7 @@ function TypeChildren({
                 }}
               />
               {signature.description ? (
-                <MDXRenderer
-                  children={signature.description}
-                  {...mdxRendererProps}
-                />
+                <MDX children={signature.description} {...mdxProps} />
               ) : null}
               {signature.parameters.length > 0 ? (
                 <div>
@@ -611,9 +605,7 @@ function TypeValue({
         </div>
       </div>
 
-      {type.description && (
-        <MDXRenderer children={type.description} {...mdxRendererProps} />
-      )}
+      {type.description && <MDX children={type.description} {...mdxProps} />}
 
       {type.kind === 'Object' && type.properties
         ? type.properties.map((propertyType, index) => (

--- a/packages/renoun/src/components/CodeBlock/QuickInfo.tsx
+++ b/packages/renoun/src/components/CodeBlock/QuickInfo.tsx
@@ -29,7 +29,7 @@ const Table = styled('table', {
   },
 })
 
-const mdxRendererProps = {
+const mdxProps = {
   components: {
     pre: (props) => {
       return <CodeBlock {...parsePreProps(props)} shouldAnalyze={false} />
@@ -140,7 +140,7 @@ export async function QuickInfo({
               >
                 <Markdown
                   children={quickInfo.documentationText}
-                  {...mdxRendererProps}
+                  {...mdxProps}
                 />
               </MarkdownContainer>
             </>

--- a/packages/renoun/src/components/MDX.examples.tsx
+++ b/packages/renoun/src/components/MDX.examples.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { MDX } from 'renoun/components'
+
+export function Basic() {
+  return <MDX># Hello World</MDX>
+}

--- a/packages/renoun/src/components/MDX.mdx
+++ b/packages/renoun/src/components/MDX.mdx
@@ -1,0 +1,7 @@
+## Security
+
+This component evaluates JavaScript. Always sanitize user-provided content before passing it to the `MDX` component. This includes sanitizing `value`, `components`, and `dependencies`.
+
+Failing to do so puts you at risk of a cross-site scripting (XSS) attack. See the [MDX security documentation](https://mdxjs.com/getting-started#security) for more information.
+
+Prefer the [`Markdown` component](https://renoun.dev/components/markdown) if possible for rendering untrusted content as it does not evaluate JavaScript and is therefore safe by default.

--- a/packages/renoun/src/components/MDX.tsx
+++ b/packages/renoun/src/components/MDX.tsx
@@ -4,7 +4,7 @@ import type { MDXComponents } from '@renoun/mdx'
 
 import { getMDXRuntimeValue } from '../utils/get-mdx-runtime-value.js'
 
-export interface MDXRendererProps {
+export interface MDXProps {
   /** The MDX content to render. */
   children: string
 
@@ -25,14 +25,14 @@ export interface MDXRendererProps {
 }
 
 /** Compiles and renders a string of MDX content. */
-export async function MDXRenderer({
+export async function MDX({
   children,
   components,
   dependencies,
   remarkPlugins,
   rehypePlugins,
   baseUrl,
-}: MDXRendererProps) {
+}: MDXProps) {
   const { default: Content } = await getMDXRuntimeValue({
     value: children,
     dependencies,

--- a/packages/renoun/src/components/MDXRenderer.examples.tsx
+++ b/packages/renoun/src/components/MDXRenderer.examples.tsx
@@ -1,6 +1,0 @@
-import React from 'react'
-import { MDXRenderer } from 'renoun/components'
-
-export function Basic() {
-  return <MDXRenderer># Hello World</MDXRenderer>
-}

--- a/packages/renoun/src/components/MDXRenderer.mdx
+++ b/packages/renoun/src/components/MDXRenderer.mdx
@@ -1,5 +1,0 @@
-## Security
-
-Always sanitize user-provided content before passing it to `MDXRenderer`. This includes sanitizing `value`, `components`, and `dependencies`.
-
-Failing to do so puts you at risk of a cross-site scripting (XSS) attack. See the [MDX security documentation](https://mdxjs.com/getting-started#security) for more information.

--- a/packages/renoun/src/components/index.ts
+++ b/packages/renoun/src/components/index.ts
@@ -18,7 +18,7 @@ export {
 export { Copyright } from './Copyright.js'
 export { GitProviderLogo, GitProviderLink } from './GitProvider.js'
 export { Markdown } from './Markdown.js'
-export { MDXRenderer } from './MDXRenderer.js'
+export { MDX as MDX } from './MDX.js'
 export { PackageInstall, PackageInstallScript } from './PackageInstall/index.js'
 export { Refresh } from './Refresh/index.js'
 export { ThemeProvider, ThemeStyles } from './Theme/index.js'


### PR DESCRIPTION
Renames the `MDXRenderer` component to `MDX`. This is to better align with the new `Markdown` component.

### Breaking Changes

Rename any `MDXRenderer` component references imported from `renoun/components` to `MDX`.
