### PR TITLE
rename path methods

### DIFF
--- a/.changeset/fifty-kids-stare.md
+++ b/.changeset/fifty-kids-stare.md
@@ -1,10 +1,25 @@
 ---
-'renoun': major
+'renoun': minor
 ---
 
-Renames the following `Directory` and `File` methods to be more aligned with their intended use:
+Renames the `Directory` and `File` path methods to better align with their intended use. The `basePath` constructor option has also been renamed to `baseRoutePath` to match the new naming convention. Additionally, the `baseRoutePath` option now defaults to the root directory's slug since this is the most common use case.
+
+### Breaking Changes
+
+Rename any call sites that use the following `Directory` and `File` methods:
 
 - `getPath` to `getRoutePath`
 - `getPathSegments` to `getRouteSegments`
 
-The `basePath` constructor option has also been renamed to `baseRoutePath` to match the new naming convention. Additionally, the `baseRoutePath` option now defaults to the root directory's slug since this is the most common use case.
+In most cases, you can remove the `baseRoutePath` option from your code if you were using it to set the base path for a directory. It now defaults to the root directory's slug:
+
+```diff
+import { Directory } from 'renoun/file-system';
+
+const directory = new Directory({
+    path: 'components',
+--  basePath: 'components'
+});
+const file = await directory.getFile('button')
+file.getRoutePath() // '/components/button'
+```

--- a/.changeset/fifty-kids-stare.md
+++ b/.changeset/fifty-kids-stare.md
@@ -1,0 +1,10 @@
+---
+'renoun': major
+---
+
+Renames the following `Directory` and `File` methods to be more aligned with their intended use:
+
+- `getPath` to `getRoutePath`
+- `getPathSegments` to `getRouteSegments`
+
+The `basePath` constructor option has also been renamed to `baseRoutePath` to match the new naming convention. Additionally, the `baseRoutePath` option now defaults to the root directory's slug since this is the most common use case.

--- a/apps/site/app/(site)/components/[...slug]/page.tsx
+++ b/apps/site/app/(site)/components/[...slug]/page.tsx
@@ -19,7 +19,7 @@ export async function generateStaticParams() {
   const entries = await ComponentsCollection.getEntries({ recursive: true })
 
   return entries.map((entry) => ({
-    slug: entry.getPathSegments({ includeBasePath: false }),
+    slug: entry.getRouteSegments({ includeBasePath: false }),
   }))
 }
 

--- a/apps/site/app/(site)/components/page.tsx
+++ b/apps/site/app/(site)/components/page.tsx
@@ -29,8 +29,8 @@ export default async function Components() {
       <Row>
         {entries.map((entry) => (
           <Card
-            key={entry.getPath()}
-            href={entry.getPath()}
+            key={entry.getRoutePath()}
+            href={entry.getRoutePath()}
             label={entry.getBaseName()}
           />
         ))}

--- a/apps/site/app/(site)/docs/[...slug]/page.tsx
+++ b/apps/site/app/(site)/docs/[...slug]/page.tsx
@@ -5,7 +5,7 @@ export async function generateStaticParams() {
   const entries = await DocsCollection.getEntries()
 
   return entries.map((entry) => ({
-    slug: entry.getPathSegments({ includeBasePath: false }),
+    slug: entry.getRouteSegments({ includeBasePath: false }),
   }))
 }
 

--- a/apps/site/app/(site)/guides/[...slug]/page.tsx
+++ b/apps/site/app/(site)/guides/[...slug]/page.tsx
@@ -5,7 +5,7 @@ export async function generateStaticParams() {
   const entries = await GuidesCollection.getEntries()
 
   return entries.map((entry) => ({
-    slug: entry.getPathSegments({ includeBasePath: false }),
+    slug: entry.getRouteSegments({ includeBasePath: false }),
   }))
 }
 

--- a/apps/site/collections/renoun.ts
+++ b/apps/site/collections/renoun.ts
@@ -31,7 +31,7 @@ async function filterInternalExports(entry: FileSystemEntry<any>) {
 export const FileSystemCollection = new Directory({
   path: '../../packages/renoun/src/file-system',
   tsConfigPath: '../../packages/renoun/tsconfig.json',
-  basePath: 'utilities',
+  baseRoutePath: 'utilities',
   loaders: {
     mdx: withSchema(
       (path) => import(`../../../packages/renoun/src/file-system/${path}.mdx`)
@@ -45,7 +45,6 @@ type ComponentSchema = Record<string, React.ComponentType>
 export const ComponentsCollection = new Directory({
   path: '../../packages/renoun/src/components',
   tsConfigPath: '../../packages/renoun/tsconfig.json',
-  basePath: 'components',
   loaders: {
     ts: withSchema<ComponentSchema>(
       (path) => import(`../../../packages/renoun/src/components/${path}.ts`)

--- a/apps/site/collections/site.ts
+++ b/apps/site/collections/site.ts
@@ -20,7 +20,6 @@ const mdxSchema = {
 
 export const DocsCollection = new Directory({
   path: 'docs',
-  basePath: 'docs',
   loaders: {
     mdx: withSchema(mdxSchema, (path) => import(`@/docs/${path}.mdx`)),
   },
@@ -29,7 +28,6 @@ export const DocsCollection = new Directory({
 
 export const GuidesCollection = new Directory({
   path: 'guides',
-  basePath: 'guides',
   loaders: {
     mdx: withSchema(mdxSchema, (path) => import(`@/guides/${path}.mdx`)),
   },

--- a/apps/site/components/SiblingLink.tsx
+++ b/apps/site/components/SiblingLink.tsx
@@ -33,7 +33,7 @@ export async function SiblingLink({
 
   return (
     <StyledLink
-      href={entry.getPath()}
+      href={entry.getRoutePath()}
       css={{
         gridTemplateColumns:
           direction === 'previous' ? 'min-content auto' : 'auto min-content',

--- a/apps/site/components/Sidebar/TreeNavigation.tsx
+++ b/apps/site/components/Sidebar/TreeNavigation.tsx
@@ -17,7 +17,7 @@ async function ListNavigation({
   entry: FileSystemEntry<any>
   variant?: 'name' | 'title'
 }) {
-  const path = entry.getPath()
+  const path = entry.getRoutePath()
   const depth = entry.getDepth()
   const metadata =
     variant === 'title' && (isJavaScriptFile(entry) || isMDXFile(entry))
@@ -104,7 +104,7 @@ async function ListNavigation({
       <ul style={listStyles}>
         {entries.map((childEntry) => (
           <ListNavigation
-            key={childEntry.getPath()}
+            key={childEntry.getRoutePath()}
             entry={childEntry}
             variant={variant}
           />
@@ -136,7 +136,7 @@ export async function TreeNavigation({
       {entries.map((entry) => {
         return (
           <ListNavigation
-            key={entry.getPath()}
+            key={entry.getRoutePath()}
             entry={entry}
             variant={variant}
           />

--- a/apps/site/docs/02.getting-started.mdx
+++ b/apps/site/docs/02.getting-started.mdx
@@ -186,7 +186,7 @@ export default async function Page() {
       <h1>Blog</h1>
       <ul>
         {allPosts.map((post) => {
-          const path = post.getPath()
+          const path = post.getRoutePath()
 
           return (
             <li key={path}>

--- a/apps/site/guides/02.next.mdx
+++ b/apps/site/guides/02.next.mdx
@@ -210,7 +210,7 @@ export default async function Page() {
       <h1>Blog</h1>
       <ul>
         {allPosts.map(async (post) => {
-          const path = post.getPath()
+          const path = post.getRoutePath()
 
           return (
             <li key={path}>

--- a/apps/site/guides/AllGuides.tsx
+++ b/apps/site/guides/AllGuides.tsx
@@ -10,7 +10,7 @@ export async function AllGuides() {
     return (
       <Card
         key={index}
-        href={entry.getPath()}
+        href={entry.getRoutePath()}
         label={metadata.label ?? metadata.title}
       />
     )

--- a/examples/blog/app/page.tsx
+++ b/examples/blog/app/page.tsx
@@ -9,7 +9,7 @@ export default async function Page() {
       <h1>Blog</h1>
       <ul>
         {allPosts.map(async (post) => {
-          const path = post.getPath()
+          const path = post.getRoutePath()
           const frontmatter = await post.getExportValue('frontmatter')
 
           return (

--- a/examples/design-system/app/components/[slug]/page.tsx
+++ b/examples/design-system/app/components/[slug]/page.tsx
@@ -242,7 +242,7 @@ async function SiblingLink({
 }) {
   return (
     <Link
-      href={entry.getPath()}
+      href={entry.getRoutePath()}
       style={{
         gridColumn: direction === 'previous' ? 1 : 2,
         textAlign: direction === 'previous' ? 'left' : 'right',

--- a/examples/design-system/app/components/page.tsx
+++ b/examples/design-system/app/components/page.tsx
@@ -24,7 +24,7 @@ export default async function Components() {
         }}
       >
         {entries.map((entry) => (
-          <ComponentEntry key={entry.getPath()} entry={entry} />
+          <ComponentEntry key={entry.getRoutePath()} entry={entry} />
         ))}
       </ul>
     </main>
@@ -36,7 +36,7 @@ const StyledLink = styled(Link, { display: 'block', padding: '1rem' })
 async function ComponentEntry({ entry }: { entry: FileSystemEntry<any> }) {
   return (
     <li>
-      <StyledLink href={entry.getPath()}>
+      <StyledLink href={entry.getRoutePath()}>
         <h2 css={{ margin: 0 }}>{entry.getBaseName()}</h2>
       </StyledLink>
     </li>

--- a/examples/design-system/collections.ts
+++ b/examples/design-system/collections.ts
@@ -2,7 +2,6 @@ import { Directory } from 'renoun/file-system'
 
 export const ComponentsCollection = new Directory({
   path: 'components',
-  basePath: 'components',
   loaders: {
     ts: (path) => import(`./components/${path}.ts`),
     tsx: (path) => import(`./components/${path}.tsx`),

--- a/packages/renoun/README.md
+++ b/packages/renoun/README.md
@@ -306,7 +306,7 @@ export default async function Page() {
       <h1>Blog</h1>
       <ul>
         {allPosts.map(async (post) => {
-          const path = post.getPath()
+          const path = post.getRoutePath()
           const frontmatter = await post.getExportValue('frontmatter')
 
           return (

--- a/packages/renoun/src/file-system/FileSystem.ts
+++ b/packages/renoun/src/file-system/FileSystem.ts
@@ -53,7 +53,7 @@ export abstract class FileSystem {
     return relativePath(rootDirectory, this.getAbsolutePath(path))
   }
 
-  getPath(path: string, options: { basePath?: string } = {}) {
+  getRoutePath(path: string, options: { basePath?: string } = {}) {
     const relativePath = this.getRelativePath(
       removeAllExtensions(removeOrderPrefixes(path))
     )

--- a/packages/renoun/src/file-system/README.mdx
+++ b/packages/renoun/src/file-system/README.mdx
@@ -65,7 +65,7 @@ export default async function Page() {
       <h1>Blog</h1>
       <ul>
         {allPosts.map(async (post) => {
-          const path = post.getPath()
+          const path = post.getRoutePath()
           const frontmatter = await post.getExportValue('frontmatter')
 
           return (

--- a/packages/renoun/src/file-system/index.tsx
+++ b/packages/renoun/src/file-system/index.tsx
@@ -356,7 +356,7 @@ export class File<
    * option will be used to format each segment.
    */
   getRoutePath(options?: {
-    includeBasePath?: string
+    includeBasePath?: boolean
     includeDuplicateSegments?: boolean
   }) {
     const includeBasePath = options?.includeBasePath ?? true
@@ -402,15 +402,10 @@ export class File<
 
   /** Get the route path segments for this file. */
   getRouteSegments(options?: {
-    includeBasePath?: string
+    includeBasePath?: boolean
     includeDuplicateSegments?: boolean
   }) {
-    return this.getRoutePath({
-      includeBasePath: options?.includeBasePath,
-      includeDuplicateSegments: options?.includeDuplicateSegments ?? false,
-    })
-      .split('/')
-      .filter(Boolean)
+    return this.getRoutePath(options).split('/').filter(Boolean)
   }
 
   /** Get the file path relative to the root directory. */
@@ -2094,10 +2089,7 @@ export class Directory<
   }
 
   /** Get a URL-friendly path to this directory. */
-  getRoutePath(options?: {
-    /** Include a base path in the route path. */
-    includeBasePath?: string
-  }) {
+  getRoutePath(options?: { includeBasePath?: boolean }) {
     const includeBasePath = options?.includeBasePath ?? true
     const fileSystem = this.getFileSystem()
     const path = fileSystem.getRoutePath(
@@ -2119,7 +2111,7 @@ export class Directory<
   }
 
   /** Get the route path segments to this directory. */
-  getRouteSegments(options?: { includeBasePath?: string }) {
+  getRouteSegments(options?: { includeBasePath?: boolean }) {
     return this.getRoutePath(options).split('/').filter(Boolean)
   }
 


### PR DESCRIPTION
Renames the `Directory` and `File` path methods to better align with their intended use. The `basePath` constructor option has also been renamed to `baseRoutePath` to match the new naming convention. Additionally, the `baseRoutePath` option now defaults to the root directory's slug since this is the most common use case.

### Breaking Changes

Rename any call sites that use the following `Directory` and `File` methods:

- `getPath` to `getRoutePath`
- `getPathSegments` to `getRouteSegments`

In most cases, you can remove the `baseRoutePath` option from your code if you were using it to set the base path for a directory. It now defaults to the root directory's slug:

```diff
import { Directory } from 'renoun/file-system';

const directory = new Directory({
    path: 'components',
--  basePath: 'components'
});
const file = await directory.getFile('button')
file.getRoutePath() // '/components/button'
```
