### PR TITLE
improve Directory sort option

### DIFF
--- a/.changeset/yummy-boxes-worry.md
+++ b/.changeset/yummy-boxes-worry.md
@@ -4,6 +4,8 @@
 
 Updates the `Directory` constructor `sort` option to now accept either a string or a sort descriptor using a new `createSort` utility. This new API makes it easier to sort entries while ensuring sorting stays performant by calculating asynchronous keys upfront and then comparing them synchronously.
 
+This also fixes a bug when using `Directory#getEntries({ recursive: true })` where the results were not being sorted at each depth.
+
 ### Breaking Changes
 
 The `Directory` constructor `sort` option now requires either a string or a sort descriptor using the new `createSort` utility.

--- a/.changeset/yummy-boxes-worry.md
+++ b/.changeset/yummy-boxes-worry.md
@@ -1,0 +1,66 @@
+---
+'renoun': major
+---
+
+Updates the `Directory` constructor `sort` option to now accept a string and optionally a sort descriptor using a new `createSort` utility. This now ensures sorting is performant by calculating keys upfront and then comparing them. Additionally, a string can now be passed for simpler cases.
+
+### Breaking Changes
+
+The `Directory` constructor `sort` option now requires `createSort`, previously sorting was defined in one function:
+
+```tsx
+import { Directory } from 'renoun/file-system'
+
+const directory = new Directory<{ mdx: { frontmatter: { date: Date } } }>({
+  include: '*.mdx',
+  sort: async (a, b) => {
+    const aFrontmatter = await a.getExportValue('frontmatter')
+    const bFrontmatter = await b.getExportValue('frontmatter')
+
+    return bFrontmatter.date.getTime() - aFrontmatter.date.getTime()
+  },
+})
+```
+
+Now this should be split into a sort `key` resolver and the `compare` function:
+
+```tsx
+import { Directory, createSort } from 'renoun/file-system'
+
+const directory = new Directory<{ mdx: { frontmatter: { date: Date } } }>({
+  include: '*.mdx',
+  sort: createSort({
+    key: (entry) => {
+      return entry
+        .getExportValue('frontmatter')
+        .then((frontmatter) => frontmatter.date)
+    },
+    compare: (a, b) => a - b,
+  }),
+})
+```
+
+For common use cases, this can be further simplified now by defining a valid sort key directly:
+
+```tsx
+import { Directory, createSort } from 'renoun/file-system'
+
+const directory = new Directory<{ mdx: { frontmatter: { date: Date } } }>({
+  include: '*.mdx',
+  sort: 'frontmatter.date',
+})
+```
+
+Note, the value being sorted is taken into consideration. Dates will be sorted descending, while other values will default to ascending. If you need further control, but do not want to fully customize using `createSort`, a `direction` can be provided as well:
+
+```tsx
+import { Directory, createSort } from 'renoun/file-system'
+
+const directory = new Directory<{ mdx: { frontmatter: { date: Date } } }>({
+  include: '*.mdx',
+  sort: {
+    key: 'frontmatter.date',
+    direction: 'acscending',
+  },
+})
+```

--- a/.changeset/yummy-boxes-worry.md
+++ b/.changeset/yummy-boxes-worry.md
@@ -2,11 +2,13 @@
 'renoun': major
 ---
 
-Updates the `Directory` constructor `sort` option to now accept a string and optionally a sort descriptor using a new `createSort` utility. This now ensures sorting is performant by calculating keys upfront and then comparing them. Additionally, a string can now be passed for simpler cases.
+Updates the `Directory` constructor `sort` option to now accept either a string or a sort descriptor using a new `createSort` utility. This new API makes it easier to sort entries while ensuring sorting stays performant by calculating asynchronous keys upfront and then comparing them synchronously.
 
 ### Breaking Changes
 
-The `Directory` constructor `sort` option now requires `createSort`, previously sorting was defined in one function:
+The `Directory` constructor `sort` option now requires either a string or a sort descriptor using the new `createSort` utility.
+
+Previously, sorting was defined in one function:
 
 ```tsx
 import { Directory } from 'renoun/file-system'
@@ -22,7 +24,7 @@ const directory = new Directory<{ mdx: { frontmatter: { date: Date } } }>({
 })
 ```
 
-Now this should be split into a sort `key` resolver and the `compare` function:
+Now, a sort descriptor requires defining a `key` resolver and `compare` function:
 
 ```tsx
 import { Directory, createSort } from 'renoun/file-system'
@@ -40,7 +42,7 @@ const directory = new Directory<{ mdx: { frontmatter: { date: Date } } }>({
 })
 ```
 
-For common use cases, this can be further simplified now by defining a valid sort key directly:
+For common use cases, this can be further simplified by defining a valid sort key directly:
 
 ```tsx
 import { Directory, createSort } from 'renoun/file-system'
@@ -51,7 +53,7 @@ const directory = new Directory<{ mdx: { frontmatter: { date: Date } } }>({
 })
 ```
 
-Note, the value being sorted is taken into consideration. Dates will be sorted descending, while other values will default to ascending. If you need further control, but do not want to fully customize using `createSort`, a `direction` can be provided as well:
+Note, the value being sorted is taken into consideration. Dates will be sorted descending, while other values will default to ascending. If you need further control, but do not want to fully customize the sort descriptor using `createSort`, a `direction` can be provided as well:
 
 ```tsx
 import { Directory, createSort } from 'renoun/file-system'
@@ -60,7 +62,7 @@ const directory = new Directory<{ mdx: { frontmatter: { date: Date } } }>({
   include: '*.mdx',
   sort: {
     key: 'frontmatter.date',
-    direction: 'acscending',
+    direction: 'ascending',
   },
 })
 ```

--- a/apps/site/app/(home)/QuickSteps.tsx
+++ b/apps/site/app/(home)/QuickSteps.tsx
@@ -27,12 +27,7 @@ export const posts = new Directory({
       (path) => import(\`./posts/\${path\}.mdx\`)
     ),
   },
-  sort: async (a, b) => {
-    const aFrontmatter = await a.getExportValue('frontmatter')
-    const bFrontmatter = await b.getExportValue('frontmatter')
-
-    return bFrontmatter.date.getTime() - aFrontmatter.date.getTime()
-  },
+  sort: 'frontmatter.date',
 })`,
     cta: {
       label: 'View Utilities',

--- a/apps/site/app/(site)/components/[...slug]/page.tsx
+++ b/apps/site/app/(site)/components/[...slug]/page.tsx
@@ -71,7 +71,7 @@ export default async function Component({
     exampleFiles = await examplesEntry
       .getEntries({
         includeIndexAndReadmeFiles: true,
-        includeTsConfigIgnoredFiles: true,
+        includeTsConfigExcludedFiles: true,
       })
       .then((entries) => entries.filter((entry) => isFile(entry, 'tsx')))
   } else if (isFile(examplesEntry, 'tsx')) {

--- a/examples/blog/collections.ts
+++ b/examples/blog/collections.ts
@@ -17,10 +17,5 @@ export const posts = new Directory({
       (path) => import(`./posts/${path}.mdx`)
     ),
   },
-  sort: async (a, b) => {
-    const aFrontmatter = await a.getExportValue('frontmatter')
-    const bFrontmatter = await b.getExportValue('frontmatter')
-
-    return bFrontmatter.date.getTime() - aFrontmatter.date.getTime()
-  },
+  sort: 'frontmatter.date',
 })

--- a/examples/docs/collections.ts
+++ b/examples/docs/collections.ts
@@ -18,41 +18,7 @@ export const docs = new Directory({
       (path) => import(`./docs/${path}.mdx`)
     ),
   },
-  sort: async (a, b) => {
-    // Prioritize shallower depth first.
-    const depthDifference = a.getDepth() - b.getDepth()
-    if (depthDifference !== 0) {
-      return depthDifference
-    }
-
-    // Compare explicit `order` metadata if present.
-    const [aOrder, bOrder] = await Promise.all([
-      a.getExportValue('metadata').then((metadata) => metadata.order),
-      b.getExportValue('metadata').then((metadata) => metadata.order),
-    ])
-    if (aOrder !== null && bOrder !== null && aOrder !== bOrder) {
-      return aOrder - bOrder
-    }
-    if (aOrder !== null && bOrder === null) {
-      return -1
-    }
-    if (aOrder === null && bOrder !== null) {
-      return 1
-    }
-
-    // When order is the same or missing, prefer directories before files so directory listings appear first.
-    const aIsDirectory = a instanceof Directory
-    const bIsDirectory = b instanceof Directory
-    if (aIsDirectory && !bIsDirectory) {
-      return -1
-    }
-    if (!aIsDirectory && bIsDirectory) {
-      return 1
-    }
-
-    // Fallback to base name comparison.
-    return a.getBaseName().localeCompare(b.getBaseName())
-  },
+  sort: 'metadata.order',
 })
 
 export const routes = docs.getEntries({ recursive: true }).then((entries) =>
@@ -63,6 +29,19 @@ export const routes = docs.getEntries({ recursive: true }).then((entries) =>
       title: await doc
         .getExportValue('metadata')
         .then((metadata) => metadata.title),
+      depth: doc.getDepth(),
+      order: await doc
+        .getExportValue('metadata')
+        .then((metadata) => metadata.order),
     }))
   )
 )
+
+// sort by order
+// console.log(
+//   await routes.then((r) => {
+//     return r.toSorted((a, b) => {
+//       return a.order - b.order
+//     })
+//   })
+// )

--- a/examples/docs/collections.ts
+++ b/examples/docs/collections.ts
@@ -36,12 +36,3 @@ export const routes = docs.getEntries({ recursive: true }).then((entries) =>
     }))
   )
 )
-
-// sort by order
-// console.log(
-//   await routes.then((r) => {
-//     return r.toSorted((a, b) => {
-//       return a.order - b.order
-//     })
-//   })
-// )


### PR DESCRIPTION
Updates the `Directory` constructor `sort` option to now accept either a string or a sort descriptor using a new `createSort` utility. This new API makes it easier to sort entries while ensuring sorting stays performant by calculating asynchronous keys upfront and then comparing them synchronously.

This also fixes a bug when using `Directory#getEntries({ recursive: true })` where the results were not being sorted at each depth.

### Breaking Changes

The `Directory` constructor `sort` option now requires either a string or a sort descriptor using the new `createSort` utility.

Previously, sorting was defined in one function:

```tsx
import { Directory } from 'renoun/file-system'

const directory = new Directory<{ mdx: { frontmatter: { date: Date } } }>({
  include: '*.mdx',
  sort: async (a, b) => {
    const aFrontmatter = await a.getExportValue('frontmatter')
    const bFrontmatter = await b.getExportValue('frontmatter')

    return bFrontmatter.date.getTime() - aFrontmatter.date.getTime()
  },
})
```

Now, a sort descriptor requires defining a `key` resolver and `compare` function:

```tsx
import { Directory, createSort } from 'renoun/file-system'

const directory = new Directory<{ mdx: { frontmatter: { date: Date } } }>({
  include: '*.mdx',
  sort: createSort({
    key: (entry) => {
      return entry
        .getExportValue('frontmatter')
        .then((frontmatter) => frontmatter.date)
    },
    compare: (a, b) => a - b,
  }),
})
```

For common use cases, this can be further simplified by defining a valid sort key directly:

```tsx
import { Directory, createSort } from 'renoun/file-system'

const directory = new Directory<{ mdx: { frontmatter: { date: Date } } }>({
  include: '*.mdx',
  sort: 'frontmatter.date',
})
```

Note, the value being sorted is taken into consideration. Dates will be sorted descending, while other values will default to ascending. If you need further control, but do not want to fully customize the sort descriptor using `createSort`, a `direction` can be provided as well:

```tsx
import { Directory, createSort } from 'renoun/file-system'

const directory = new Directory<{ mdx: { frontmatter: { date: Date } } }>({
  include: '*.mdx',
  sort: {
    key: 'frontmatter.date',
    direction: 'ascending',
  },
})
```
