### PR TITLE
feat: support windows paths

### DIFF
--- a/packages/renoun/src/file-system/MemoryFileSystem.ts
+++ b/packages/renoun/src/file-system/MemoryFileSystem.ts
@@ -4,7 +4,7 @@ import * as tsMorph from 'ts-morph'
 import { createSourceFile, transpileSourceFile } from '../project/client.js'
 import type { ProjectOptions } from '../project/types.js'
 import { isJavaScriptLikeExtension } from '../utils/is-javascript-like-extension.js'
-import { joinPaths } from '../utils/path.js'
+import { joinPaths, normalizeSlashes } from '../utils/path.js'
 import { FileSystem } from './FileSystem.js'
 import type { DirectoryEntry } from './types.js'
 
@@ -28,7 +28,7 @@ export class MemoryFileSystem extends FileSystem {
     }
     this.#files = new Map(
       Object.entries(files).map(([path, content]) => [
-        path.startsWith('.') ? path : `./${path}`,
+        normalizeSlashes(path.startsWith('.') ? path : `./${path}`),
         content,
       ])
     )
@@ -43,7 +43,9 @@ export class MemoryFileSystem extends FileSystem {
   }
 
   createFile(path: string, content: string): void {
-    const normalizedPath = path.startsWith('.') ? path : `./${path}`
+    const normalizedPath = normalizeSlashes(
+      path.startsWith('.') ? path : `./${path}`
+    )
     this.#files.set(normalizedPath, content)
 
     const extension = normalizedPath.split('.').pop()
@@ -57,10 +59,12 @@ export class MemoryFileSystem extends FileSystem {
   }
 
   transpileFile(path: string) {
+    path = normalizeSlashes(path)
     return transpileSourceFile(path, this.#projectOptions)
   }
 
   getAbsolutePath(path: string) {
+    path = normalizeSlashes(path)
     if (path.startsWith('/')) {
       return path
     }
@@ -71,6 +75,7 @@ export class MemoryFileSystem extends FileSystem {
   }
 
   getRelativePathToWorkspace(path: string) {
+    path = normalizeSlashes(path)
     return path.startsWith('.') ? path : `./${path}`
   }
 
@@ -82,6 +87,7 @@ export class MemoryFileSystem extends FileSystem {
     if (!path.startsWith('.')) {
       path = `./${path}`
     }
+    path = normalizeSlashes(path)
 
     const entries: DirectoryEntry[] = []
     const addedPaths = new Set<string>()

--- a/packages/renoun/src/utils/file-path-to-pathname.test.ts
+++ b/packages/renoun/src/utils/file-path-to-pathname.test.ts
@@ -95,6 +95,12 @@ describe('filePathToPathname', () => {
     )
   })
 
+  test('handles windows paths', () => {
+    expect(
+      filePathToPathname('src\\components\\Button\\index.tsx', 'src')
+    ).toBe('/components/button/index')
+  })
+
   test('handles camel case file names', () => {
     expect(filePathToPathname('src/hooks/useHover.ts', 'src')).toBe(
       '/hooks/use-hover'

--- a/packages/renoun/src/utils/file-path-to-pathname.ts
+++ b/packages/renoun/src/utils/file-path-to-pathname.ts
@@ -1,6 +1,7 @@
 import { posix } from 'node:path'
 
 import { createSlug } from './create-slug.js'
+import { normalizeSlashes } from './path.js'
 
 /** Converts a file system path to a URL-friendly pathname. */
 export function filePathToPathname(
@@ -16,6 +17,11 @@ export function filePathToPathname(
   /** Whether or not to convert the pathname to kebab case. */
   kebabCase = true
 ) {
+  filePath = normalizeSlashes(filePath)
+  if (baseDirectory) {
+    baseDirectory = normalizeSlashes(baseDirectory)
+  }
+
   if (filePath.includes('node_modules')) {
     return ''
   }

--- a/packages/renoun/src/utils/path.test.ts
+++ b/packages/renoun/src/utils/path.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest'
+
+import { joinPaths, relativePath } from './path.js'
+
+describe('path utilities windows support', () => {
+  test('joinPaths normalizes backslashes', () => {
+    expect(joinPaths('src\\components', 'Button\\index.tsx')).toBe(
+      'src/components/Button/index.tsx'
+    )
+  })
+
+  test('relativePath handles windows separators', () => {
+    expect(
+      relativePath('src\\components\\Button', 'src\\utils\\index.ts')
+    ).toBe('../../utils/index.ts')
+  })
+})
+

--- a/packages/renoun/src/utils/path.ts
+++ b/packages/renoun/src/utils/path.ts
@@ -1,5 +1,11 @@
+/** Normalize Windows backslashes to POSIX forward slashes. */
+export function normalizeSlashes(path: string): string {
+  return path.replace(/\\+/g, '/')
+}
+
 /** Get the base name of a file system path e.g. /path/to/file.ts -> file */
 export function baseName(path: string, extension?: string): string {
+  path = normalizeSlashes(path)
   const base = path.slice(path.lastIndexOf('/') + 1)
   if (extension && base.endsWith(extension)) {
     return base.slice(0, -extension.length)
@@ -9,6 +15,7 @@ export function baseName(path: string, extension?: string): string {
 
 /** Get the extension from a file path e.g. readme.md -> .md */
 export function extensionName(path: string): string {
+  path = normalizeSlashes(path)
   const dotIndex = path.lastIndexOf('.')
   const slashIndex = path.lastIndexOf('/')
   if (dotIndex > slashIndex) {
@@ -19,6 +26,7 @@ export function extensionName(path: string): string {
 
 /** Get the directory name from a file path e.g. /path/to/file.ts -> /path/to */
 export function directoryName(path: string): string {
+  path = normalizeSlashes(path)
   const slashIndex = path.lastIndexOf('/')
   if (slashIndex === -1) return '.'
   if (slashIndex === 0) return '/'
@@ -27,11 +35,9 @@ export function directoryName(path: string): string {
 
 /** Remove the extension from a file path e.g. readme.md -> readme */
 export function removeExtension(filePath: string): string {
+  filePath = normalizeSlashes(filePath)
   const lastDotIndex = filePath.lastIndexOf('.')
-  const lastSlashIndex = Math.max(
-    filePath.lastIndexOf('/'),
-    filePath.lastIndexOf('\\')
-  )
+  const lastSlashIndex = filePath.lastIndexOf('/')
 
   if (lastDotIndex > lastSlashIndex) {
     return filePath.slice(0, lastDotIndex)
@@ -42,10 +48,8 @@ export function removeExtension(filePath: string): string {
 
 /** Remove all extensions from a file path e.g. Button.examples.tsx -> Button */
 export function removeAllExtensions(filePath: string): string {
-  const lastSlashIndex = Math.max(
-    filePath.lastIndexOf('/'),
-    filePath.lastIndexOf('\\')
-  )
+  filePath = normalizeSlashes(filePath)
+  const lastSlashIndex = filePath.lastIndexOf('/')
   const filenNameStartOffset = 1
   const fileName = filePath.slice(lastSlashIndex + filenNameStartOffset)
   const firstDotIndex = fileName.lastIndexOf('.')
@@ -62,6 +66,7 @@ export function removeAllExtensions(filePath: string): string {
 
 /** Remove order prefixes from a file path e.g. 01.intro -> intro */
 export function removeOrderPrefixes(filePath: string): string {
+  filePath = normalizeSlashes(filePath)
   return filePath.replace(/(^|\/)\d+\./g, '$1')
 }
 
@@ -71,7 +76,8 @@ export function joinPaths(...paths: (string | undefined)[]): string {
     return '.'
   }
 
-  const isAbsolute = paths.at(0)?.startsWith('/')
+  const firstPath = paths.at(0) ? normalizeSlashes(paths[0]!) : ''
+  const isAbsolute = firstPath.startsWith('/')
   const segments: string[] = []
   const lastSegmentIndex = paths.length - 1
   let hasTrailingSlash = false
@@ -84,10 +90,10 @@ export function joinPaths(...paths: (string | undefined)[]): string {
     }
 
     if (index === lastSegmentIndex) {
-      hasTrailingSlash = path.endsWith('/')
+      hasTrailingSlash = path.endsWith('/') || path.endsWith('\\')
     }
 
-    for (const segment of path.split('/')) {
+    for (const segment of normalizeSlashes(path).split('/')) {
       if (segment === '..') {
         if (isAbsolute || segments.length > 0) {
           segments.pop() // Go up one directory
@@ -110,8 +116,8 @@ export function joinPaths(...paths: (string | undefined)[]): string {
 
 /** Get the relative path from one file to another */
 export function relativePath(from: string, to: string): string {
-  const fromParts = from.split('/').filter(Boolean)
-  const toParts = to.split('/').filter(Boolean)
+  const fromParts = normalizeSlashes(from).split('/').filter(Boolean)
+  const toParts = normalizeSlashes(to).split('/').filter(Boolean)
 
   let commonIndex = 0
   while (

--- a/packages/renoun/src/utils/resolve-type.ts
+++ b/packages/renoun/src/utils/resolve-type.ts
@@ -31,6 +31,7 @@ import {
 import { getJsDocMetadata } from './get-js-doc-metadata.js'
 import { getSymbolDescription } from './get-symbol-description.js'
 import { getRootDirectory } from './get-root-directory.js'
+import { normalizeSlashes } from './path.js'
 
 export namespace Kind {
   /** Metadata present in all types. */
@@ -3138,8 +3139,10 @@ function getDeclarationLocation(declaration: Node): {
 /** Calculate a file path of a source file relative to the project root. */
 function getFilePathRelativeToProject(declaration: Node) {
   const sourceFile = declaration.getSourceFile()
-  const rootFilePath = getRootFilePath(sourceFile.getProject())
-  let trimmedFilePath = sourceFile.getFilePath().replace(rootFilePath, '')
+  const rootFilePath = normalizeSlashes(getRootFilePath(sourceFile.getProject()))
+  let trimmedFilePath = normalizeSlashes(
+    sourceFile.getFilePath()
+  ).replace(rootFilePath, '')
 
   if (trimmedFilePath.includes('node_modules')) {
     trimmedFilePath = trimmedFilePath.slice(
@@ -3159,7 +3162,9 @@ function getRootFilePath(project: Project) {
   let rootFilePath: string
 
   if (!rootFilePaths.has(project)) {
-    rootFilePath = project.getFileSystem().getCurrentDirectory()
+    rootFilePath = normalizeSlashes(
+      project.getFileSystem().getCurrentDirectory()
+    )
     rootFilePaths.set(project, rootFilePath)
   } else {
     rootFilePath = rootFilePaths.get(project)!


### PR DESCRIPTION
## Summary
- normalize path utilities to handle Windows-style separators
- handle Windows paths in memory filesystem and file lookups
- add tests for Windows path handling

## Testing
- `pnpm -F renoun vitest run --typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6890de6e695c832eb2d6214da1d1827f