### PR TITLE
add GitProviderFileSystem utility

### DIFF
--- a/.changeset/metal-olives-fold.md
+++ b/.changeset/metal-olives-fold.md
@@ -1,0 +1,5 @@
+---
+'renoun': minor
+---
+
+Adds a `GitProviderFileSystem` utility that extends `MemoryFileSystem` by fetching a git provider repository using the respective provider's API to allow enumeration of the repository's contents.

--- a/packages/renoun/src/file-system/GitProviderFileSystem.ts
+++ b/packages/renoun/src/file-system/GitProviderFileSystem.ts
@@ -210,6 +210,12 @@ export class GitProviderFileSystem extends MemoryFileSystem {
             response.headers.get('X-RateLimit-Remaining') === '0')
 
         if (isRateLimited) {
+          const retryAfter = Number(response.headers.get('Retry-After'))
+          if (Number.isFinite(retryAfter)) {
+            await sleep((retryAfter + 1) * 1000)
+            continue
+          }
+
           const delay = getResetDelayMs(response, this.#provider)
           if (delay !== undefined) {
             await sleep(delay)

--- a/packages/renoun/src/file-system/GitProviderFileSystem.ts
+++ b/packages/renoun/src/file-system/GitProviderFileSystem.ts
@@ -1,6 +1,7 @@
 import { MemoryFileSystem } from './MemoryFileSystem.js'
 import type { DirectoryEntry } from './types.js'
 
+type GitProvider = 'github' | 'gitlab' | 'bitbucket'
 interface GitProviderFileSystemOptions {
   /** Repository in the format "owner/repo". */
   repository: string
@@ -9,7 +10,7 @@ interface GitProviderFileSystemOptions {
   ref?: string
 
   /** Git provider host */
-  provider: 'github' | 'gitlab' | 'bitbucket'
+  provider: GitProvider
 
   /** Personal-access / OAuth token for private repositories or higher rate limits. */
   token?: string
@@ -21,37 +22,67 @@ interface GitProviderFileSystemOptions {
   cacheTTL?: number
 }
 
-const binaryExtensions = new Set([
-  'png',
-  'jpg',
-  'jpeg',
-  'gif',
-  'webp',
-  'svg',
-  'ico',
-  'pdf',
-  'zip',
-  'rar',
-  '7z',
-  'gz',
-  'tar',
-  'mp3',
-  'mp4',
-  'mov',
-  'avi',
-  'mkv',
-  'wasm',
-])
+const binaryExtensions = Object.freeze(
+  new Set([
+    'png',
+    'jpg',
+    'jpeg',
+    'gif',
+    'webp',
+    'svg',
+    'ico',
+    'pdf',
+    'zip',
+    'rar',
+    '7z',
+    'gz',
+    'tar',
+    'mp3',
+    'mp4',
+    'mov',
+    'avi',
+    'mkv',
+    'wasm',
+  ])
+)
+
+const repoPattern = /^[^/]+\/[^/]+$/
 
 function normalizePath(path: string) {
-  if (path === '.' || path === './') return ''
-  return path.replace(/^\.\//, '').replace(/\/$/, '')
+  if (path === '.' || path === './') {
+    return ''
+  }
+
+  const parts = path.replace(/\\/g, '/').split('/').filter(Boolean)
+  const stack: string[] = []
+
+  for (const part of parts) {
+    if (part === '.') {
+      continue
+    }
+    if (part === '..') {
+      stack.pop()
+    } else {
+      stack.push(part)
+    }
+  }
+
+  return stack.join('/')
+}
+
+function decodeBase64(string: string) {
+  if (typeof Buffer === 'undefined') {
+    return new TextDecoder().decode(
+      Uint8Array.from(atob(string), (character) => character.charCodeAt(0))
+    )
+  }
+  return Buffer.from(string, 'base64').toString('utf-8')
 }
 
 export class GitProviderFileSystem extends MemoryFileSystem {
   #repository: string
   #ref: string
-  #provider: 'github' | 'gitlab' | 'bitbucket'
+  #provider: GitProvider
   #token?: string
   #timeoutMs: number
   #cacheTTL?: number
@@ -59,9 +90,18 @@ export class GitProviderFileSystem extends MemoryFileSystem {
     string,
     { entries: DirectoryEntry[]; cachedAt: number }
   >()
+  #fileFetches = new Map<string, Promise<void>>() // in-flight dedupe
 
   constructor(options: GitProviderFileSystemOptions) {
+    if (!repoPattern.test(options.repository)) {
+      throw new Error('[renoun] Repository must be in "owner/repo" format')
+    }
+    if (!['github', 'gitlab', 'bitbucket'].includes(options.provider)) {
+      throw new Error('[renoun] Unsupported git provider')
+    }
+
     super({})
+
     this.#repository = options.repository
     this.#ref = options.ref ?? 'main'
     this.#provider = options.provider
@@ -71,23 +111,27 @@ export class GitProviderFileSystem extends MemoryFileSystem {
   }
 
   clearCache(path?: string) {
-    if (path === undefined) {
-      this.#directoryCache.clear()
-    } else {
-      this.#directoryCache.delete(normalizePath(path))
-    }
+    path
+      ? this.#directoryCache.delete(normalizePath(path))
+      : this.#directoryCache.clear()
   }
 
   #getHeaders(): Record<string, string> {
     const headers: Record<string, string> = {}
 
-    if (this.#provider === 'github')
+    if (this.#provider === 'github') {
       headers['Accept'] = 'application/vnd.github.v3+json'
-    if (!this.#token) return headers
+    }
+
+    if (!this.#token) {
+      return headers
+    }
 
     switch (this.#provider) {
       case 'github':
-        headers['Authorization'] = `token ${this.#token}`
+        headers['Authorization'] = /^gh[pus]_|^github_pat_/.test(this.#token)
+          ? `Bearer ${this.#token}`
+          : `token ${this.#token}`
         break
       case 'gitlab':
         headers['PRIVATE-TOKEN'] = this.#token
@@ -101,6 +145,10 @@ export class GitProviderFileSystem extends MemoryFileSystem {
   }
 
   async #fetchWithRetry(url: string, attempts = 3): Promise<Response> {
+    if (attempts < 1) {
+      attempts = 1
+    }
+
     for (let index = 0; index < attempts; index++) {
       const controller = new AbortController()
       const timer = setTimeout(() => controller.abort(), this.#timeoutMs)
@@ -112,7 +160,9 @@ export class GitProviderFileSystem extends MemoryFileSystem {
         })
         if (
           response.ok ||
-          (response.status < 500 && response.status !== 429) // do not retry 4xx except 429
+          (response.status >= 400 &&
+            response.status < 500 &&
+            response.status !== 429)
         ) {
           return response
         }
@@ -130,7 +180,8 @@ export class GitProviderFileSystem extends MemoryFileSystem {
       const backoff = 2 ** index * 200 + Math.random() * 100
       await new Promise((r) => setTimeout(r, backoff))
     }
-    throw new Error(`[renoun] Failed to fetch after retries`)
+
+    throw new Error(`[renoun] Failed to fetch after ${attempts} attempts`)
   }
 
   #encodePath(path: string) {
@@ -142,7 +193,6 @@ export class GitProviderFileSystem extends MemoryFileSystem {
 
   async #fetchDirectory(path: string): Promise<DirectoryEntry[]> {
     const entries: DirectoryEntry[] = []
-
     const pushEntries = (items: any[]) => {
       switch (this.#provider) {
         case 'github':
@@ -150,7 +200,7 @@ export class GitProviderFileSystem extends MemoryFileSystem {
             ...items.map((item) => ({
               name: item.name,
               path: path ? `./${path}/${item.name}` : `./${item.name}`,
-              isDirectory: item.type === 'dir',
+              isDirectory: item.type === 'dir' || item.type === 'submodule',
               isFile: item.type === 'file',
             }))
           )
@@ -182,7 +232,6 @@ export class GitProviderFileSystem extends MemoryFileSystem {
       const apiPath = path ? `/${this.#encodePath(path)}` : ''
       const perPage = 100
       let page = 1
-
       while (true) {
         const url = `https://api.github.com/repos/${this.#repository}/contents${apiPath}?ref=${this.#ref}&per_page=${perPage}&page=${page}`
         const response = await this.#fetchWithRetry(url)
@@ -199,11 +248,10 @@ export class GitProviderFileSystem extends MemoryFileSystem {
         if (data.length < perPage) {
           break
         }
-        page += 1
-      }
-    }
 
-    if (this.#provider === 'gitlab') {
+        page++
+      }
+    } else if (this.#provider === 'gitlab') {
       const repo = encodeURIComponent(this.#repository)
       const perPage = 100
       let page = 1
@@ -214,7 +262,11 @@ export class GitProviderFileSystem extends MemoryFileSystem {
           per_page: String(perPage),
           page: String(page),
         })
-        if (path) params.set('path', path)
+
+        if (path) {
+          params.set('path', path)
+        }
+
         const url = `https://gitlab.com/api/v4/projects/${repo}/repository/tree?${params}`
         const response = await this.#fetchWithRetry(url)
 
@@ -225,29 +277,35 @@ export class GitProviderFileSystem extends MemoryFileSystem {
         }
 
         const data = (await response.json()) as any[]
+
         pushEntries(data)
 
         const nextPage = response.headers.get('X-Next-Page')
-        if (!nextPage) break
-        page = Number(nextPage)
-        if (!page) break
-      }
-    }
 
-    if (this.#provider === 'bitbucket') {
+        if (!nextPage) {
+          break
+        }
+
+        page = Number(nextPage) || 0
+
+        if (!page) {
+          break
+        }
+      }
+    } else {
       let next: string | undefined = path
-        ? `https://api.bitbucket.org/2.0/repositories/${this.#repository}/src/${this.#ref}/${this.#encodePath(path)}?format=meta&pagelen=100`
+        ? `https://api.bitbucket.org/2.0/repositories/${this.#repository}/src/${this.#ref}/${this.#encodePath(
+            path
+          )}?format=meta&pagelen=100`
         : `https://api.bitbucket.org/2.0/repositories/${this.#repository}/src/${this.#ref}?format=meta&pagelen=100`
 
       while (next) {
         const response = await this.#fetchWithRetry(next)
-
         if (!response.ok) {
           throw new Error(
             `[renoun] Failed to fetch directory "${path}": ${response.status} ${response.statusText}`
           )
         }
-
         const data = (await response.json()) as any
         pushEntries(data.values)
         next = data.next
@@ -263,6 +321,7 @@ export class GitProviderFileSystem extends MemoryFileSystem {
     const cached = this.#directoryCache.get(key)
     if (
       cached &&
+      this.#cacheTTL !== 0 &&
       (!this.#cacheTTL || Date.now() - cached.cachedAt < this.#cacheTTL)
     ) {
       return cached.entries
@@ -289,7 +348,9 @@ export class GitProviderFileSystem extends MemoryFileSystem {
 
     switch (this.#provider) {
       case 'github':
-        url = `https://api.github.com/repos/${this.#repository}/contents/${this.#encodePath(normalizedPath)}?ref=${this.#ref}`
+        url = `https://api.github.com/repos/${this.#repository}/contents/${this.#encodePath(
+          normalizedPath
+        )}?ref=${this.#ref}`
         break
       case 'gitlab': {
         const repo = encodeURIComponent(this.#repository)
@@ -298,10 +359,10 @@ export class GitProviderFileSystem extends MemoryFileSystem {
         break
       }
       case 'bitbucket':
-        url = `https://api.bitbucket.org/2.0/repositories/${this.#repository}/src/${this.#ref}/${this.#encodePath(normalizedPath)}`
+        url = `https://api.bitbucket.org/2.0/repositories/${this.#repository}/src/${this.#ref}/${this.#encodePath(
+          normalizedPath
+        )}`
         break
-      default:
-        throw new Error(`[renoun] Unsupported git provider: ${this.#provider}`)
     }
 
     const response = await this.#fetchWithRetry(url)
@@ -312,38 +373,36 @@ export class GitProviderFileSystem extends MemoryFileSystem {
       )
     }
 
-    switch (this.#provider) {
-      case 'github': {
-        const data = await response.json()
-        if (typeof data.content === 'string' && data.encoding === 'base64') {
-          const content = Buffer.from(data.content, 'base64').toString('utf-8')
-          this.createFile(path, content)
-        } else if (typeof data.download_url === 'string') {
-          const response = await this.#fetchWithRetry(data.download_url)
-          const content = await response.text()
-          this.createFile(path, content)
-        } else {
-          const rawUrl = `https://raw.githubusercontent.com/${this.#repository}/${this.#ref}/${normalizedPath}`
-          const response = await this.#fetchWithRetry(rawUrl)
-          const content = await response.text()
-          this.createFile(path, content)
-        }
-        break
+    if (this.#provider === 'github') {
+      const data = await response.json()
+      if (typeof data.content === 'string' && data.encoding === 'base64') {
+        this.createFile(path, decodeBase64(data.content))
+      } else if (typeof data.download_url === 'string') {
+        const rawResponse = await this.#fetchWithRetry(data.download_url)
+        this.createFile(path, await rawResponse.text())
+      } else {
+        const rawUrl = `https://raw.githubusercontent.com/${this.#repository}/${this.#ref}/${normalizedPath}`
+        const rawResponse = await this.#fetchWithRetry(rawUrl)
+        this.createFile(path, await rawResponse.text())
       }
-      case 'gitlab':
-      case 'bitbucket': {
-        const content = await response.text()
-        this.createFile(path, content)
-        break
-      }
+    } else {
+      this.createFile(path, await response.text())
     }
   }
 
   async readFile(path: string): Promise<string> {
-    if (!this.fileExistsSync(path)) {
-      await this.#fetchFile(path)
+    const key = normalizePath(path)
+    if (!this.fileExistsSync(key)) {
+      let fetchPromise = this.#fileFetches.get(key)
+      if (!fetchPromise) {
+        fetchPromise = this.#fetchFile(path).finally(() =>
+          this.#fileFetches.delete(key)
+        )
+        this.#fileFetches.set(key, fetchPromise)
+      }
+      await fetchPromise
     }
-    return super.readFile(path)
+    return super.readFile(key)
   }
 
   readFileSync(): string {

--- a/packages/renoun/src/file-system/GitProviderFileSystem.ts
+++ b/packages/renoun/src/file-system/GitProviderFileSystem.ts
@@ -1,0 +1,201 @@
+import { MemoryFileSystem } from './MemoryFileSystem.js'
+import type { DirectoryEntry } from './types.js'
+
+interface GitProviderFileSystemOptions {
+  /** Repository in the format "owner/repo". */
+  repository: string
+
+  /** Branch, tag, or commit reference. Defaults to 'main'. */
+  ref?: string
+
+  /** Git provider host */
+  provider: 'github' | 'gitlab' | 'bitbucket'
+}
+
+/**
+ * A file system backed by a remote git provider. Files are fetched lazily via
+ * provider APIs and cached in-memory.
+ */
+export class GitProviderFileSystem extends MemoryFileSystem {
+  #repository: string
+  #ref: string
+  #provider: 'github' | 'gitlab' | 'bitbucket'
+  #directoryCache = new Map<string, DirectoryEntry[]>()
+
+  constructor(options: GitProviderFileSystemOptions) {
+    super({})
+    this.#repository = options.repository
+    this.#ref = options.ref ?? 'main'
+    this.#provider = options.provider
+  }
+
+  async #fetchDirectory(path: string): Promise<DirectoryEntry[]> {
+    let url: string
+
+    switch (this.#provider) {
+      case 'github': {
+        const apiPath = path ? `/${path}` : ''
+        url = `https://api.github.com/repos/${this.#repository}/contents${apiPath}?ref=${this.#ref}`
+        break
+      }
+      case 'gitlab': {
+        const repo = encodeURIComponent(this.#repository)
+        const params = new URLSearchParams({ ref: this.#ref })
+        if (path) params.set('path', path)
+        url = `https://gitlab.com/api/v4/projects/${repo}/repository/tree?${params}`
+        break
+      }
+      case 'bitbucket': {
+        const base = `https://api.bitbucket.org/2.0/repositories/${this.#repository}/src/${this.#ref}`
+        url = path ? `${base}/${path}?format=meta` : `${base}?format=meta`
+        break
+      }
+      default:
+        throw new Error(`[renoun] Unsupported git provider: ${this.#provider}`)
+    }
+
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(
+        `[renoun] Failed to fetch directory "${path}": ${response.statusText}`
+      )
+    }
+
+    let entries: DirectoryEntry[]
+
+    switch (this.#provider) {
+      case 'github': {
+        const data = (await response.json()) as any[]
+        entries = data.map((item) => ({
+          name: item.name,
+          path: path ? `./${path}/${item.name}` : `./${item.name}`,
+          isDirectory: item.type === 'dir',
+          isFile: item.type === 'file',
+        }))
+        break
+      }
+      case 'gitlab': {
+        const data = (await response.json()) as any[]
+        entries = data.map((item) => ({
+          name: item.name,
+          path: path ? `./${path}/${item.name}` : `./${item.name}`,
+          isDirectory: item.type === 'tree',
+          isFile: item.type === 'blob',
+        }))
+        break
+      }
+      case 'bitbucket': {
+        const data = (await response.json()) as any
+        entries = data.values.map((item: any) => ({
+          name: item.path.split('/').pop(),
+          path: `./${item.path}`,
+          isDirectory: item.type === 'commit_directory',
+          isFile: item.type === 'commit_file',
+        }))
+        break
+      }
+    }
+
+    this.#directoryCache.set(path, entries)
+    return entries
+  }
+
+  async readDirectory(path: string = '.'): Promise<DirectoryEntry[]> {
+    if (!path.startsWith('.')) {
+      path = `./${path}`
+    }
+    const normalized = path === '.' ? '' : path.replace(/^\.\//, '')
+    if (this.#directoryCache.has(normalized)) {
+      return this.#directoryCache.get(normalized)!
+    }
+    return this.#fetchDirectory(normalized)
+  }
+
+  readDirectorySync(_path: string = '.'): DirectoryEntry[] {
+    throw new Error(
+      'readDirectorySync is not supported in GitProviderFileSystem'
+    )
+  }
+
+  async #fetchFile(path: string): Promise<void> {
+    const normalized = path.replace(/^\.\//, '')
+    let url: string
+
+    switch (this.#provider) {
+      case 'github':
+        url = `https://api.github.com/repos/${this.#repository}/contents/${normalized}?ref=${this.#ref}`
+        break
+      case 'gitlab': {
+        const repo = encodeURIComponent(this.#repository)
+        const filePath = encodeURIComponent(normalized)
+        url = `https://gitlab.com/api/v4/projects/${repo}/repository/files/${filePath}/raw?ref=${this.#ref}`
+        break
+      }
+      case 'bitbucket':
+        url = `https://api.bitbucket.org/2.0/repositories/${this.#repository}/src/${this.#ref}/${normalized}`
+        break
+      default:
+        throw new Error(`[renoun] Unsupported git provider: ${this.#provider}`)
+    }
+
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(
+        `[renoun] Failed to fetch file "${path}": ${response.statusText}`
+      )
+    }
+
+    switch (this.#provider) {
+      case 'github': {
+        const data = await response.json()
+        if (typeof data.content === 'string' && data.encoding === 'base64') {
+          const content = Buffer.from(data.content, 'base64').toString('utf-8')
+          this.createFile(path, content)
+        } else if (typeof data.download_url === 'string') {
+          const res = await fetch(data.download_url)
+          const content = await res.text()
+          this.createFile(path, content)
+        } else {
+          throw new Error(`[renoun] Unsupported file response for "${path}"`)
+        }
+        break
+      }
+      case 'gitlab': {
+        const content = await response.text()
+        this.createFile(path, content)
+        break
+      }
+      case 'bitbucket': {
+        const content = await response.text()
+        this.createFile(path, content)
+        break
+      }
+    }
+  }
+
+  async readFile(path: string): Promise<string> {
+    if (!this.fileExistsSync(path)) {
+      await this.#fetchFile(path)
+    }
+    return super.readFile(path)
+  }
+
+  readFileSync(path: string): string {
+    return super.readFileSync(path)
+  }
+
+  fileExistsSync(path: string): boolean {
+    return super.fileExistsSync(path)
+  }
+
+  isFilePathGitIgnored(_filePath: string): boolean {
+    return false
+  }
+
+  override isFilePathExcludedFromTsConfig(
+    _filePath: string,
+    _isDirectory = false
+  ) {
+    return false
+  }
+}

--- a/packages/renoun/src/file-system/GitProviderFileSystem.ts
+++ b/packages/renoun/src/file-system/GitProviderFileSystem.ts
@@ -10,6 +10,15 @@ interface GitProviderFileSystemOptions {
 
   /** Git provider host */
   provider: 'github' | 'gitlab' | 'bitbucket'
+
+  /** Personal-access / OAuth token for private repositories or higher rate limits. */
+  token?: string
+
+  /** Request timeout in milliseconds. Defaults to 30 seconds. */
+  timeoutMs?: number
+
+  /** Time-to-live for directory cache in milliseconds. Unlimited when `undefined`. */
+  cacheTTL?: number
 }
 
 /**
@@ -20,83 +29,193 @@ export class GitProviderFileSystem extends MemoryFileSystem {
   #repository: string
   #ref: string
   #provider: 'github' | 'gitlab' | 'bitbucket'
-  #directoryCache = new Map<string, DirectoryEntry[]>()
+  #token?: string
+  #timeoutMs: number
+  #cacheTTL?: number
+  #directoryCache = new Map<
+    string,
+    { entries: DirectoryEntry[]; cachedAt: number }
+  >()
 
   constructor(options: GitProviderFileSystemOptions) {
     super({})
     this.#repository = options.repository
     this.#ref = options.ref ?? 'main'
     this.#provider = options.provider
+    this.#token = options.token
+    this.#timeoutMs = options.timeoutMs ?? 30_000
+    this.#cacheTTL = options.cacheTTL
+  }
+
+  #getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {}
+
+    if (this.#provider === 'github') {
+      headers['Accept'] = 'application/vnd.github.v3+json'
+    }
+
+    if (this.#token) {
+      switch (this.#provider) {
+        case 'github':
+          headers['Authorization'] = `token ${this.#token}`
+          break
+        case 'gitlab':
+          headers['PRIVATE-TOKEN'] = this.#token
+          break
+        case 'bitbucket':
+          headers['Authorization'] = `Bearer ${this.#token}`
+          break
+      }
+    }
+
+    return headers
+  }
+
+  async #fetchWithTimeout(url: string): Promise<Response> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.#timeoutMs)
+
+    try {
+      return await fetch(url, {
+        headers: this.#getHeaders(),
+        signal: controller.signal,
+      })
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  #encodePath(path: string) {
+    return path
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/')
   }
 
   async #fetchDirectory(path: string): Promise<DirectoryEntry[]> {
-    let url: string
+    const entries: DirectoryEntry[] = []
 
-    switch (this.#provider) {
-      case 'github': {
-        const apiPath = path ? `/${path}` : ''
-        url = `https://api.github.com/repos/${this.#repository}/contents${apiPath}?ref=${this.#ref}`
-        break
+    const pushEntries = (items: any[]) => {
+      switch (this.#provider) {
+        case 'github':
+          entries.push(
+            ...items.map((item) => ({
+              name: item.name,
+              path: path ? `./${path}/${item.name}` : `./${item.name}`,
+              isDirectory: item.type === 'dir',
+              isFile: item.type === 'file',
+            }))
+          )
+          break
+        case 'gitlab':
+          entries.push(
+            ...items.map((item) => ({
+              name: item.name,
+              path: path ? `./${path}/${item.name}` : `./${item.name}`,
+              isDirectory: item.type === 'tree',
+              isFile: item.type === 'blob',
+            }))
+          )
+          break
+        case 'bitbucket':
+          entries.push(
+            ...items.map((item: any) => ({
+              name: item.path.split('/').pop(),
+              path: `./${item.path}`,
+              isDirectory: item.type === 'commit_directory',
+              isFile: item.type === 'commit_file',
+            }))
+          )
+          break
       }
-      case 'gitlab': {
-        const repo = encodeURIComponent(this.#repository)
-        const params = new URLSearchParams({ ref: this.#ref })
+    }
+
+    if (this.#provider === 'github') {
+      const apiPath = path ? `/${this.#encodePath(path)}` : ''
+      const perPage = 100
+      let page = 1
+
+      while (true) {
+        const url = `https://api.github.com/repos/${this.#repository}/contents${apiPath}?ref=${this.#ref}&per_page=${perPage}&page=${page}`
+        const response = await this.#fetchWithTimeout(url)
+
+        if (!response.ok) {
+          throw new Error(
+            `[renoun] Failed to fetch directory "${path}": ${response.status} ${response.statusText}`
+          )
+        }
+
+        const data = (await response.json()) as any[]
+        pushEntries(data)
+
+        // Last page reached
+        if (data.length < perPage) {
+          break
+        }
+
+        page += 1
+      }
+    }
+
+    if (this.#provider === 'gitlab') {
+      const repo = encodeURIComponent(this.#repository)
+      const perPage = 100
+      let page = 1
+
+      while (true) {
+        const params = new URLSearchParams({
+          ref: this.#ref,
+          per_page: String(perPage),
+          page: String(page),
+        })
         if (path) params.set('path', path)
-        url = `https://gitlab.com/api/v4/projects/${repo}/repository/tree?${params}`
-        break
+        const url = `https://gitlab.com/api/v4/projects/${repo}/repository/tree?${params}`
+        const response = await this.#fetchWithTimeout(url)
+
+        if (!response.ok) {
+          throw new Error(
+            `[renoun] Failed to fetch directory "${path}": ${response.status} ${response.statusText}`
+          )
+        }
+
+        const data = (await response.json()) as any[]
+        pushEntries(data)
+
+        const nextPage = response.headers.get('X-Next-Page')
+
+        if (!nextPage) {
+          break
+        }
+
+        page = Number(nextPage)
+
+        if (!page) {
+          break
+        }
       }
-      case 'bitbucket': {
-        const base = `https://api.bitbucket.org/2.0/repositories/${this.#repository}/src/${this.#ref}`
-        url = path ? `${base}/${path}?format=meta` : `${base}?format=meta`
-        break
-      }
-      default:
-        throw new Error(`[renoun] Unsupported git provider: ${this.#provider}`)
     }
 
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(
-        `[renoun] Failed to fetch directory "${path}": ${response.statusText}`
-      )
-    }
+    if (this.#provider === 'bitbucket') {
+      let next: string | undefined = path
+        ? `https://api.bitbucket.org/2.0/repositories/${this.#repository}/src/${this.#ref}/${this.#encodePath(path)}?format=meta`
+        : `https://api.bitbucket.org/2.0/repositories/${this.#repository}/src/${this.#ref}?format=meta`
 
-    let entries: DirectoryEntry[]
+      while (next) {
+        const response = await this.#fetchWithTimeout(next)
 
-    switch (this.#provider) {
-      case 'github': {
-        const data = (await response.json()) as any[]
-        entries = data.map((item) => ({
-          name: item.name,
-          path: path ? `./${path}/${item.name}` : `./${item.name}`,
-          isDirectory: item.type === 'dir',
-          isFile: item.type === 'file',
-        }))
-        break
-      }
-      case 'gitlab': {
-        const data = (await response.json()) as any[]
-        entries = data.map((item) => ({
-          name: item.name,
-          path: path ? `./${path}/${item.name}` : `./${item.name}`,
-          isDirectory: item.type === 'tree',
-          isFile: item.type === 'blob',
-        }))
-        break
-      }
-      case 'bitbucket': {
+        if (!response.ok) {
+          throw new Error(
+            `[renoun] Failed to fetch directory "${path}": ${response.status} ${response.statusText}`
+          )
+        }
+
         const data = (await response.json()) as any
-        entries = data.values.map((item: any) => ({
-          name: item.path.split('/').pop(),
-          path: `./${item.path}`,
-          isDirectory: item.type === 'commit_directory',
-          isFile: item.type === 'commit_file',
-        }))
-        break
+        pushEntries(data.values)
+        next = data.next
       }
     }
 
-    this.#directoryCache.set(path, entries)
+    this.#directoryCache.set(path, { entries, cachedAt: Date.now() })
     return entries
   }
 
@@ -104,10 +223,18 @@ export class GitProviderFileSystem extends MemoryFileSystem {
     if (!path.startsWith('.')) {
       path = `./${path}`
     }
+
     const normalized = path === '.' ? '' : path.replace(/^\.\//, '')
-    if (this.#directoryCache.has(normalized)) {
-      return this.#directoryCache.get(normalized)!
+    const cached = this.#directoryCache.get(normalized)
+
+    if (cached) {
+      if (!this.#cacheTTL || Date.now() - cached.cachedAt < this.#cacheTTL) {
+        return cached.entries
+      }
+      // Stale cache -> evict
+      this.#directoryCache.delete(normalized)
     }
+
     return this.#fetchDirectory(normalized)
   }
 
@@ -123,7 +250,7 @@ export class GitProviderFileSystem extends MemoryFileSystem {
 
     switch (this.#provider) {
       case 'github':
-        url = `https://api.github.com/repos/${this.#repository}/contents/${normalized}?ref=${this.#ref}`
+        url = `https://api.github.com/repos/${this.#repository}/contents/${this.#encodePath(normalized)}?ref=${this.#ref}`
         break
       case 'gitlab': {
         const repo = encodeURIComponent(this.#repository)
@@ -132,16 +259,17 @@ export class GitProviderFileSystem extends MemoryFileSystem {
         break
       }
       case 'bitbucket':
-        url = `https://api.bitbucket.org/2.0/repositories/${this.#repository}/src/${this.#ref}/${normalized}`
+        url = `https://api.bitbucket.org/2.0/repositories/${this.#repository}/src/${this.#ref}/${this.#encodePath(normalized)}`
         break
       default:
         throw new Error(`[renoun] Unsupported git provider: ${this.#provider}`)
     }
 
-    const response = await fetch(url)
+    const response = await this.#fetchWithTimeout(url)
+
     if (!response.ok) {
       throw new Error(
-        `[renoun] Failed to fetch file "${path}": ${response.statusText}`
+        `[renoun] Failed to fetch file "${path}": ${response.status} ${response.statusText}`
       )
     }
 
@@ -152,11 +280,15 @@ export class GitProviderFileSystem extends MemoryFileSystem {
           const content = Buffer.from(data.content, 'base64').toString('utf-8')
           this.createFile(path, content)
         } else if (typeof data.download_url === 'string') {
-          const res = await fetch(data.download_url)
+          const res = await this.#fetchWithTimeout(data.download_url)
           const content = await res.text()
           this.createFile(path, content)
         } else {
-          throw new Error(`[renoun] Unsupported file response for "${path}"`)
+          // Fallback to raw URL for large/binary files
+          const rawUrl = `https://raw.githubusercontent.com/${this.#repository}/${this.#ref}/${normalized}`
+          const res = await this.#fetchWithTimeout(rawUrl)
+          const content = await res.text()
+          this.createFile(path, content)
         }
         break
       }
@@ -180,8 +312,8 @@ export class GitProviderFileSystem extends MemoryFileSystem {
     return super.readFile(path)
   }
 
-  readFileSync(path: string): string {
-    return super.readFileSync(path)
+  readFileSync(_path: string): string {
+    throw new Error('readFileSync is not supported in GitProviderFileSystem')
   }
 
   fileExistsSync(path: string): boolean {

--- a/packages/renoun/src/file-system/index.tsx
+++ b/packages/renoun/src/file-system/index.tsx
@@ -43,6 +43,7 @@ import type { StandardSchemaV1 } from './standard-schema.js'
 import type { ExtractFileExtension, IsNever } from './types.js'
 
 export { FileSystem } from './FileSystem.js'
+export { GitProviderFileSystem } from './GitProviderFileSystem.js'
 export { MemoryFileSystem } from './MemoryFileSystem.js'
 export { NodeFileSystem } from './NodeFileSystem.js'
 export { Repository } from './Repository.js'

--- a/packages/renoun/src/utils/Semaphore.ts
+++ b/packages/renoun/src/utils/Semaphore.ts
@@ -1,0 +1,41 @@
+/** Simple semaphore to gate concurrency. */
+export class Semaphore {
+  #permits: number
+  #queue: Array<() => void> = []
+
+  constructor(permits: number) {
+    this.#permits = Math.max(1, permits)
+  }
+
+  getQueueLength() {
+    return this.#queue.length
+  }
+
+  async acquire(): Promise<() => void> {
+    if (this.#permits > 0) {
+      this.#permits--
+      let released = false
+      return () => {
+        if (released) return
+        released = true
+        this.#permits++
+        const next = this.#queue.shift()
+        if (next) next()
+      }
+    }
+
+    return new Promise<() => void>((resolve) => {
+      this.#queue.push(() => {
+        this.#permits--
+        let released = false
+        resolve(() => {
+          if (released) return
+          released = true
+          this.#permits++
+          const next = this.#queue.shift()
+          if (next) next()
+        })
+      })
+    })
+  }
+}


### PR DESCRIPTION
Adds a `GitProviderFileSystem` utility that extends `MemoryFileSystem` by fetching a git provider repository using the respective provider's API to allow enumeration of the repository's contents.