### PR TITLE
allow overriding headings

### DIFF
--- a/.changeset/add-headings-override.md
+++ b/.changeset/add-headings-override.md
@@ -20,3 +20,14 @@ This will now include the extra headings when importing them from the file:
 ```tsx allowErrors
 import Content, { headings } from 'hello-world.mdx'
 ```
+
+This feature is disabled by default for security purposes, please import and configure this plugin to enable:
+
+```tsx
+import { remarkAddHeadings } from '@renoun/mdx/add-headings'
+import { evaluate } from '@mdx-js/mdx'
+
+const result = await evaluate('# Hello World', {
+  remarkPlugins: [[addHeadings, { allowGetHeadings: true }]],
+})
+```

--- a/.changeset/add-headings-override.md
+++ b/.changeset/add-headings-override.md
@@ -1,0 +1,22 @@
+---
+'@renoun/mdx': minor
+---
+
+Allows MDX files to override the exported `headings` variable by exporting a `getHeadings` function.
+
+```hello-world.mdx
+export function getHeadings(headings) {
+  return [
+    ...headings,
+    { id: 'extra', level: 2, text: 'Extra', children: 'Extra' },
+  ]
+}
+
+# Hello World
+```
+
+This will now include the extra headings when importing them from the file:
+
+```tsx allowErrors
+import Content, { headings } from 'hello-world.mdx'
+```

--- a/apps/site/guides/01.mdx.mdx
+++ b/apps/site/guides/01.mdx.mdx
@@ -88,6 +88,30 @@ In addition to the community plugins listed above, renoun adds specific custom p
 
 Adds an `id` to all headings and exports a `headings` variable.
 
+You can customize the exported `headings` by exporting a `getHeadings` function from your MDX file. The function receives the auto-generated `headings` and should return the array you want to expose.
+
+```mdx
+export function getHeadings(headings) {
+  return [
+    ...headings,
+    {
+      id: 'custom-section',
+      level: 2,
+      text: 'Custom section',
+      children: 'Custom section',
+    },
+  ]
+}
+
+# Hello World
+```
+
+<Note>
+
+Exporting `headings` directly is not supported. If you need to override headings, export a `getHeadings(headings)` function as shown above.
+
+</Note>
+
 #### remark `remove-immediate-paragraphs`
 
 Removes paragraph elements added around immediate element and component children.

--- a/apps/site/guides/01.mdx.mdx
+++ b/apps/site/guides/01.mdx.mdx
@@ -112,6 +112,16 @@ Exporting `headings` directly is not supported. If you need to override headings
 
 </Note>
 
+##### Security considerations
+
+This plugin is designed for trusted MDX sources.
+
+`getHeadings` is executed as JavaScript at build/render time, so only use it with content from trusted authors. It can access your environment and perform arbitrary actions.
+
+All URLs in links and images are restricted to `http` and `https` schemes to prevent injection of `javascript:` or other unsafe protocols.
+
+If you need to support untrusted MDX, run the compiled output through an HTML sanitizer such as [rehype-sanitize](https://www.npmjs.com/package/rehype-sanitize) before rendering.
+
 #### remark `remove-immediate-paragraphs`
 
 Removes paragraph elements added around immediate element and component children.

--- a/packages/mdx/src/remark/add-headings.test.ts
+++ b/packages/mdx/src/remark/add-headings.test.ts
@@ -206,6 +206,30 @@ export function getHeadings(headings) {
     expect(headings[1].id).toBe('extra')
   })
 
+  test('runtime validation that getHeadings must return an array', async () => {
+    const mdxSource = `
+export function getHeadings(headings) {
+  return { pwnd: true }
+}
+
+# Hello
+`
+
+    const jsxRuntime = {
+      Fragment: Symbol.for('react.fragment'),
+      jsx: () => null,
+      jsxs: () => null,
+    }
+
+    await expect(
+      evaluate(mdxSource, {
+        remarkPlugins: [addHeadings],
+        development: false,
+        ...jsxRuntime,
+      })
+    ).rejects.toThrow(/getHeadings\(headings\) must return an array/)
+  })
+
   test('throws when exporting headings directly with guidance', async () => {
     const mdxSource = `
 export const headings = []

--- a/packages/mdx/src/remark/add-headings.test.ts
+++ b/packages/mdx/src/remark/add-headings.test.ts
@@ -12,7 +12,7 @@ describe('addHeadings', () => {
     expect(String(result)).toMatchInlineSnapshot(`
       "import {jsx as _jsx} from "react/jsx-runtime";
       export const headings = [{
-        id: "hello,-world!",
+        id: "hello-world",
         level: 1,
         children: "Hello, world!",
         text: "Hello, world!"
@@ -23,7 +23,7 @@ describe('addHeadings', () => {
           ...props.components
         };
         return _jsx(_components.h1, {
-          id: "hello,-world!",
+          id: "hello-world",
           children: "Hello, world!"
         });
       }
@@ -48,7 +48,7 @@ describe('addHeadings', () => {
     expect(String(result)).toMatchInlineSnapshot(`
       "import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
       export const headings = [{
-        id: "hello,-world!",
+        id: "hello-world",
         level: 1,
         children: _jsxs(_Fragment, {
           children: ["Hello, ", _jsx("code", {
@@ -64,7 +64,7 @@ describe('addHeadings', () => {
           ...props.components
         };
         return _jsxs(_components.h1, {
-          id: "hello,-world!",
+          id: "hello-world",
           children: ["Hello, ", _jsx(_components.code, {
             children: "world"
           }), "!"]
@@ -91,7 +91,7 @@ describe('addHeadings', () => {
     expect(String(result)).toMatchInlineSnapshot(`
       "import {jsx as _jsx} from "react/jsx-runtime";
       export const headings = [{
-        id: "hello,-world!",
+        id: "hello-world",
         level: 1,
         children: _jsx("a", {
           href: "https://example.com",
@@ -106,7 +106,7 @@ describe('addHeadings', () => {
           ...props.components
         };
         return _jsx(_components.h1, {
-          id: "hello,-world!",
+          id: "hello-world",
           children: _jsx(_components.a, {
             href: "https://example.com",
             children: "Hello, world!"
@@ -137,7 +137,7 @@ describe('addHeadings', () => {
     expect(String(result)).toMatchInlineSnapshot(`
       "import {jsx as _jsx} from "react/jsx-runtime";
       export const headings = [{
-        id: "hello,-world!",
+        id: "hello-world",
         level: 1,
         children: _jsx("img", {
           src: "https://example.com/image.png",
@@ -152,7 +152,7 @@ describe('addHeadings', () => {
           ...props.components
         };
         return _jsx(_components.h1, {
-          id: "hello,-world!",
+          id: "hello-world",
           children: _jsx(_components.img, {
             src: "https://example.com/image.png",
             alt: "Hello, world!"
@@ -192,7 +192,7 @@ export function getHeadings(headings) {
     }
 
     const result = await evaluate(mdxSource, {
-      remarkPlugins: [addHeadings],
+      remarkPlugins: [[addHeadings, { allowGetHeadings: true }]],
       development: false,
       ...jsxRuntime,
     })
@@ -223,7 +223,7 @@ export function getHeadings(headings) {
 
     await expect(
       evaluate(mdxSource, {
-        remarkPlugins: [addHeadings],
+        remarkPlugins: [[addHeadings, { allowGetHeadings: true }]],
         development: false,
         ...jsxRuntime,
       })
@@ -237,7 +237,9 @@ export const headings = []
 # Hello
 `
 
-    const vfile = await compile(mdxSource, { remarkPlugins: [addHeadings] })
+    const vfile = await compile(mdxSource, {
+      remarkPlugins: [[addHeadings, { allowGetHeadings: true }]],
+    })
     const messages = (vfile as any).messages as Array<any>
     const hasFatal = messages.some(
       (message) =>

--- a/packages/mdx/src/remark/add-headings.ts
+++ b/packages/mdx/src/remark/add-headings.ts
@@ -18,7 +18,11 @@ declare module 'mdast' {
   }
 }
 
-/** An array of headings metadata. */
+export interface AddHeadingsOptions {
+  /** Whether to allow the `getHeadings` export. */
+  allowGetHeadings?: boolean
+}
+
 export type MDXHeadings = {
   /** The slugified heading text. */
   id: string
@@ -33,9 +37,12 @@ export type MDXHeadings = {
   children?: React.ReactNode
 }[]
 
-/** Exports a `headings` variable containing an array of headings metadata. */
-export default function addHeadings(this: Processor) {
+export default function addHeadings(
+  this: Processor,
+  opts: AddHeadingsOptions = {}
+) {
   const isMarkdown = this.data('isMarkdown') === true
+  const { allowGetHeadings = false } = opts
 
   return function (tree: Root, file: VFile) {
     const headingsArray: any[] = []
@@ -47,7 +54,6 @@ export default function addHeadings(this: Processor) {
       const text = toString(node)
       let slug = createSlug(text)
 
-      // Ensure unique slugs.
       if (headingCounts.has(slug)) {
         const count = headingCounts.get(slug)! + 1
         headingCounts.set(slug, count)
@@ -86,19 +92,22 @@ export default function addHeadings(this: Processor) {
         ],
       })
 
-      // Also add an id for HTML output.
       node.data ??= {}
       node.data.hProperties ??= {}
       node.data.hProperties.id = slug
     })
 
-    // Detect `export function getHeadings` or `export const getHeadings = ...`
-    // or `export { getHeadings }` within mdx ESM blocks.
     visit(tree, (node) => {
-      // Only handle mdx ESM nodes
-      if ((node as any).type !== 'mdxjsEsm') return
+      if ((node as any).type !== 'mdxjsEsm') {
+        return
+      }
+
       const program = (node as any)?.data?.estree
-      if (!program || !Array.isArray(program.body)) return
+
+      if (!program || !Array.isArray(program.body)) {
+        return
+      }
+
       for (const statement of program.body) {
         if (statement.type !== 'ExportNamedDeclaration') continue
         if (statement.declaration) {
@@ -146,11 +155,20 @@ export default function addHeadings(this: Processor) {
 
     if (hasHeadingsExport) {
       const message = file.message(
-        '[renoun/mdx] Exporting "headings" directly is not supported. Use `export function getHeadings(headings) { ... }` to transform or replace the generated headings.',
+        '[renoun/mdx] Exporting "headings" directly is not supported. Use `export function getHeadings(headings) { ... }`.',
         undefined,
         'renoun-mdx:headings-export'
       )
-      // Mark as fatal so compilation fails fast with guidance
+      message.fatal = true
+      return
+    }
+
+    if (!allowGetHeadings && hasGetHeadingsExport) {
+      const message = file.message(
+        '[renoun/mdx] The `getHeadings` export is disabled in this environment.',
+        undefined,
+        'renoun-mdx:get-headings-disabled'
+      )
       message.fatal = true
       return
     }
@@ -212,7 +230,6 @@ export default function addHeadings(this: Processor) {
                           computed: false,
                           optional: false,
                         },
-                        optional: false,
                         arguments: [
                           {
                             type: 'Identifier',
@@ -240,7 +257,6 @@ export default function addHeadings(this: Processor) {
                         },
                       ],
                     },
-                    alternate: null,
                   },
                   {
                     type: 'ReturnStatement',
@@ -252,31 +268,29 @@ export default function addHeadings(this: Processor) {
                 ],
               },
             },
-            optional: false,
             arguments: [],
           }
         : generatedHeadingsArrayExpression
 
-      define(tree, file, {
-        headings: headingsExpression as any,
-      })
+      define(tree, file, { headings: headingsExpression as any })
     }
   }
 }
 
 /** Convert an array of mdast nodes into a text node or JSX fragment. */
 function mdastNodesToJsxFragment(nodes: any[]) {
-  const jsxChildren = nodes.map(mdastNodeToJsxChild)
+  const jsxChildren = nodes.map((node) => mdastNodeToJsxChild(node))
 
   if (jsxChildren.length === 1) {
     const child = jsxChildren[0]
 
     if (child.type === 'JSXText') {
-      return { type: 'Literal', value: child.value }
+      return {
+        type: 'Literal',
+        value: child.value,
+      }
     }
 
-    // If there is a single non-text child (e.g. a link or image), return it
-    // directly rather than wrapping in a Fragment.
     return child
   }
 
@@ -287,9 +301,7 @@ function mdastNodesToJsxFragment(nodes: any[]) {
       attributes: [],
       selfClosing: false,
     },
-    closingFragment: {
-      type: 'JSXClosingFragment',
-    },
+    closingFragment: { type: 'JSXClosingFragment' },
     children: jsxChildren,
   }
 }
@@ -307,19 +319,14 @@ function mdastNodeToJsxChild(node: any) {
   switch (node.type) {
     case 'text':
       return { type: 'JSXText', value: node.value }
-
     case 'strong':
       return makeJsxElement('strong', node.children)
-
     case 'emphasis':
       return makeJsxElement('em', node.children)
-
     case 'inlineCode':
       return makeJsxElement('code', [{ type: 'JSXText', value: node.value }])
-
     case 'delete':
       return makeJsxElement('del', node.children)
-
     case 'break':
       return {
         type: 'JSXElement',
@@ -332,75 +339,103 @@ function mdastNodeToJsxChild(node: any) {
         closingElement: null,
         children: [],
       }
-
-    case 'image': {
-      const attributes = [
-        {
-          type: 'JSXAttribute',
-          name: { type: 'JSXIdentifier', name: 'src' },
-          value: { type: 'Literal', value: node.url },
-        },
-      ]
-      if (node.alt) {
-        attributes.push({
-          type: 'JSXAttribute',
-          name: { type: 'JSXIdentifier', name: 'alt' },
-          value: { type: 'Literal', value: node.alt },
-        })
-      }
-      if (node.title) {
-        attributes.push({
-          type: 'JSXAttribute',
-          name: { type: 'JSXIdentifier', name: 'title' },
-          value: { type: 'Literal', value: node.title },
-        })
-      }
-      return {
-        type: 'JSXElement',
-        openingElement: {
-          type: 'JSXOpeningElement',
-          name: { type: 'JSXIdentifier', name: 'img' },
-          attributes,
-          selfClosing: true,
-        },
-        closingElement: null,
-        children: [],
-      }
-    }
-
-    case 'link': {
-      const attributes = [
-        {
-          type: 'JSXAttribute',
-          name: { type: 'JSXIdentifier', name: 'href' },
-          value: { type: 'Literal', value: node.url },
-        },
-      ]
-      if (node.title) {
-        attributes.push({
-          type: 'JSXAttribute',
-          name: { type: 'JSXIdentifier', name: 'title' },
-          value: { type: 'Literal', value: node.title },
-        })
-      }
-      return {
-        type: 'JSXElement',
-        openingElement: {
-          type: 'JSXOpeningElement',
-          name: { type: 'JSXIdentifier', name: 'a' },
-          attributes,
-          selfClosing: false,
-        },
-        closingElement: {
-          type: 'JSXClosingElement',
-          name: { type: 'JSXIdentifier', name: 'a' },
-        },
-        children: node.children.map(mdastNodeToJsxChild),
-      }
-    }
-
+    case 'image':
+      return makeSafeImage(node)
+    case 'link':
+      return makeSafeLink(node)
     default:
       return { type: 'JSXText', value: toString(node) }
+  }
+}
+
+/**
+ * Check if a URL is safe.
+ * It checks if the URL has a valid protocol and is not a data URI.
+ */
+function isSafeUrl(url: string) {
+  try {
+    const parsed = new URL(url, 'http://example.com')
+    return ['http:', 'https:'].includes(parsed.protocol)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Convert an mdast image node into its corresponding ESTree JSX AST node.
+ * It builds an element like <img src={url} alt={alt} title={title} />.
+ */
+function makeSafeImage(node: any) {
+  const attributes = []
+
+  if (isSafeUrl(node.url)) {
+    attributes.push({
+      type: 'JSXAttribute',
+      name: { type: 'JSXIdentifier', name: 'src' },
+      value: { type: 'Literal', value: node.url },
+    })
+  }
+  if (node.alt)
+    attributes.push({
+      type: 'JSXAttribute',
+      name: { type: 'JSXIdentifier', name: 'alt' },
+      value: { type: 'Literal', value: node.alt },
+    })
+  if (node.title)
+    attributes.push({
+      type: 'JSXAttribute',
+      name: { type: 'JSXIdentifier', name: 'title' },
+      value: { type: 'Literal', value: node.title },
+    })
+  return {
+    type: 'JSXElement',
+    openingElement: {
+      type: 'JSXOpeningElement',
+      name: { type: 'JSXIdentifier', name: 'img' },
+      attributes,
+      selfClosing: true,
+    },
+    closingElement: null,
+    children: [],
+  }
+}
+
+/**
+ * Convert an mdast link node into its corresponding ESTree JSX AST node.
+ * It builds an element like <a href={url} title={title}>{children}</a>.
+ */
+function makeSafeLink(node: any) {
+  const attributes = []
+
+  if (isSafeUrl(node.url)) {
+    attributes.push({
+      type: 'JSXAttribute',
+      name: { type: 'JSXIdentifier', name: 'href' },
+      value: { type: 'Literal', value: node.url },
+    })
+  }
+
+  if (node.title) {
+    attributes.push({
+      type: 'JSXAttribute',
+      name: { type: 'JSXIdentifier', name: 'title' },
+      value: { type: 'Literal', value: node.title },
+    })
+  }
+
+  return {
+    type: 'JSXElement',
+    openingElement: {
+      type: 'JSXOpeningElement',
+      name: { type: 'JSXIdentifier', name: 'a' },
+      attributes,
+      selfClosing: false,
+    },
+    closingElement: {
+      type: 'JSXClosingElement',
+      name: { type: 'JSXIdentifier', name: 'a' },
+    },
+    children: node.children.map((child: any) => mdastNodeToJsxChild(child)),
   }
 }
 
@@ -421,15 +456,20 @@ function makeJsxElement(tagName: string, mdastChildren: any[]): any {
       type: 'JSXClosingElement',
       name: { type: 'JSXIdentifier', name: tagName },
     },
-    children: mdastChildren.map(mdastNodeToJsxChild),
+    children: mdastChildren.map((child) => mdastNodeToJsxChild(child)),
   }
 }
 
 /** Create a slug from a string. */
 function createSlug(input: string) {
   return input
-    .replace(/([a-z])([A-Z])/g, '$1-$2') // Add a hyphen between lower and upper case letters
-    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2') // Add a hyphen between consecutive upper case letters followed by a lower case letter
-    .replace(/[_\s]+/g, '-') // Replace underscores and spaces with a hyphen
-    .toLowerCase() // Convert the entire string to lowercase
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '') // strip diacritics
+    .replace(/[\u200B-\u200D\uFEFF]/g, '') // strip zero-width
+    .replace(/([a-z\d])([A-Z])/g, '$1-$2') // split camelCase
+    .replace(/[\p{Pd}\s_]+/gu, '-') // spaces/any dash → -
+    .replace(/[^\p{Letter}\p{Number}-]+/gu, '') // drop other punct/symbols
+    .replace(/-+/g, '-') // collapse ---
+    .replace(/^-+|-+$/g, '') // trim -
+    .toLowerCase()
 }


### PR DESCRIPTION
Allows MDX files to override the exported `headings` variable by exporting a `getHeadings` function. Note, this is disabled by default, please read more below.

```hello-world.mdx
export function getHeadings(headings) {
  return [
    ...headings,
    { id: 'extra', level: 2, text: 'Extra', children: 'Extra' },
  ]
}

# Hello World
```

This will now include the extra headings when importing them from the file:

```tsx allowErrors
import Content, { headings } from 'hello-world.mdx'
```

This feature is disabled by default for security purposes, please import and configure this plugin to enable:

```tsx
import { remarkAddHeadings } from '@renoun/mdx/add-headings'
import { evaluate } from '@mdx-js/mdx'

const result = await evaluate('# Hello World', {
  remarkPlugins: [[addHeadings, { allowGetHeadings: true }]],
})
```

closes #208