### PR TITLE
add Sponsors component

### DIFF
--- a/.changeset/happy-hounds-stand.md
+++ b/.changeset/happy-hounds-stand.md
@@ -1,0 +1,5 @@
+---
+'renoun': minor
+---
+
+Adds a `Sponsors` component for rendering GitHub sponsors related to a specific user account.

--- a/apps/site/app/(site)/sponsors/SponsorTiers.tsx
+++ b/apps/site/app/(site)/sponsors/SponsorTiers.tsx
@@ -1,5 +1,4 @@
 import { Sponsors } from 'renoun/components'
-import { Markdown } from '@/components/Markdown'
 
 export const tiers = [
   {
@@ -53,9 +52,6 @@ export function SponsorTiers() {
                     <h3>
                       {tier.icon} {tier.title}
                     </h3>
-                    {tier.description && (
-                      <Markdown>{tier.description}</Markdown>
-                    )}
                     <div
                       css={{
                         display: 'flex',
@@ -103,11 +99,6 @@ export function SponsorTiers() {
                       variant="small"
                     />
                   </div>
-                  {tier.description && (
-                    <div css={{ color: 'var(--color-text-secondary)' }}>
-                      <Markdown>{tier.description}</Markdown>
-                    </div>
-                  )}
                   <ul
                     css={{
                       listStyle: 'none',

--- a/apps/site/app/(site)/sponsors/SponsorTiers.tsx
+++ b/apps/site/app/(site)/sponsors/SponsorTiers.tsx
@@ -1,0 +1,159 @@
+import { Sponsors } from 'renoun/components'
+
+export const tiers = [
+  {
+    amount: 1000,
+    title: 'Diamond',
+    icon: '💎',
+  },
+  {
+    amount: 500,
+    title: 'Gold',
+    icon: '🥇',
+  },
+  {
+    amount: 250,
+    title: 'Silver',
+    icon: '🥈',
+  },
+  {
+    amount: 100,
+    title: 'Bronze',
+    icon: '🥉',
+  },
+] as const
+
+export function SponsorTiers() {
+  return (
+    <Sponsors tiers={tiers}>
+      {(tiers) => {
+        return (
+          <div
+            css={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '3rem',
+            }}
+          >
+            {tiers.map((tier) => {
+              const id = tier.title.toLowerCase()
+
+              if (tier.sponsors.length === 0) {
+                return (
+                  <section
+                    key={tier.title}
+                    id={id}
+                    css={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: '1rem',
+                    }}
+                  >
+                    <h3>
+                      {tier.icon} {tier.title}
+                    </h3>
+                    <div
+                      css={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: '1rem',
+                        minHeight: '16rem',
+                        backgroundColor: 'var(--color-surface-secondary)',
+                      }}
+                    >
+                      <p>
+                        Become the first <strong>{tier.title}</strong> sponsor
+                      </p>
+                      <SponsorLink tier={tier.title} />
+                    </div>
+                  </section>
+                )
+              }
+
+              return (
+                <section
+                  key={tier.title}
+                  id={id}
+                  css={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '1rem',
+                  }}
+                >
+                  <div
+                    css={{
+                      display: 'flex',
+                      gap: '1rem',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <h3 css={{ margin: '0 !important' }}>
+                      {tier.icon} {tier.title}
+                    </h3>
+                    <SponsorLink tier={tier.title} variant="small" />
+                  </div>
+                  <ul
+                    css={{
+                      listStyle: 'none',
+                      display: 'flex',
+                      flexWrap: 'wrap',
+                      minHeight: '16rem',
+                      padding: '1rem',
+                      margin: 0,
+                      gap: '1rem',
+                      backgroundColor: 'var(--color-surface-secondary)',
+                    }}
+                  >
+                    {tier.sponsors.map((sponsor) => (
+                      <li key={sponsor.username}>
+                        <a href={`https://github.com/${sponsor.username}`}>
+                          <img
+                            src={sponsor.avatarUrl}
+                            alt={`${sponsor.username}'s avatar`}
+                            title={sponsor.username}
+                            css={{ width: '4rem', borderRadius: '100%' }}
+                          />
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )
+            })}
+          </div>
+        )
+      }}
+    </Sponsors>
+  )
+}
+
+function SponsorLink({
+  tier,
+  variant = 'medium',
+}: {
+  tier: string
+  variant?: 'small' | 'medium'
+}) {
+  return (
+    <a
+      href="https://github.com/sponsors/souporserious"
+      css={{
+        fontSize:
+          variant === 'small'
+            ? 'var(--font-size-body-3)'
+            : 'var(--font-size-body-2)',
+        fontWeight: 'var(--font-weight-button)',
+        display: 'inline-flex',
+        padding: variant === 'small' ? '0.25rem 0.75rem' : '0.5rem 1rem',
+        borderRadius: '0.25rem',
+        backgroundColor: '#db61a2',
+        color: 'white',
+      }}
+    >
+      Sponsor {tier}
+    </a>
+  )
+}

--- a/apps/site/app/(site)/sponsors/SponsorTiers.tsx
+++ b/apps/site/app/(site)/sponsors/SponsorTiers.tsx
@@ -66,7 +66,7 @@ export function SponsorTiers() {
                       <p>
                         Become the first <strong>{tier.title}</strong> sponsor
                       </p>
-                      <SponsorLink tier={tier.title} />
+                      <SponsorLink tier={tier.title} href={tier.href} />
                     </div>
                   </section>
                 )
@@ -93,7 +93,11 @@ export function SponsorTiers() {
                     <h3 css={{ margin: '0 !important' }}>
                       {tier.icon} {tier.title}
                     </h3>
-                    <SponsorLink tier={tier.title} variant="small" />
+                    <SponsorLink
+                      tier={tier.title}
+                      href={tier.href}
+                      variant="small"
+                    />
                   </div>
                   <ul
                     css={{
@@ -132,14 +136,16 @@ export function SponsorTiers() {
 
 function SponsorLink({
   tier,
+  href,
   variant = 'medium',
 }: {
   tier: string
+  href: string
   variant?: 'small' | 'medium'
 }) {
   return (
     <a
-      href="https://github.com/sponsors/souporserious"
+      href={href}
       css={{
         fontSize:
           variant === 'small'

--- a/apps/site/app/(site)/sponsors/SponsorTiers.tsx
+++ b/apps/site/app/(site)/sponsors/SponsorTiers.tsx
@@ -1,4 +1,5 @@
 import { Sponsors } from 'renoun/components'
+import { Markdown } from '@/components/Markdown'
 
 export const tiers = [
   {
@@ -52,6 +53,9 @@ export function SponsorTiers() {
                     <h3>
                       {tier.icon} {tier.title}
                     </h3>
+                    {tier.description && (
+                      <Markdown>{tier.description}</Markdown>
+                    )}
                     <div
                       css={{
                         display: 'flex',
@@ -99,6 +103,11 @@ export function SponsorTiers() {
                       variant="small"
                     />
                   </div>
+                  {tier.description && (
+                    <div css={{ color: 'var(--color-text-secondary)' }}>
+                      <Markdown>{tier.description}</Markdown>
+                    </div>
+                  )}
                   <ul
                     css={{
                       listStyle: 'none',

--- a/apps/site/app/(site)/sponsors/page.tsx
+++ b/apps/site/app/(site)/sponsors/page.tsx
@@ -1,13 +1,23 @@
 import { TableOfContents } from '@/components/TableOfContents'
 import Sponsors, { headings } from './sponsors.mdx'
+import { tiers, SponsorTiers } from './SponsorTiers'
+
+const sponsorHeadings = tiers.map((tier) => ({
+  id: tier.title.toLowerCase(),
+  text: tier.title,
+  level: 3,
+}))
 
 export default function Page() {
   return (
     <>
-      <main className="prose">
-        <Sponsors />
+      <main>
+        <div className="prose" css={{ marginBottom: '3rem' }}>
+          <Sponsors />
+        </div>
+        <SponsorTiers />
       </main>
-      <TableOfContents headings={headings} />
+      <TableOfContents headings={headings.concat(sponsorHeadings)} />
     </>
   )
 }

--- a/apps/site/app/(site)/sponsors/page.tsx
+++ b/apps/site/app/(site)/sponsors/page.tsx
@@ -1,8 +1,9 @@
+import type { MDXHeadings } from 'renoun/mdx'
 import { TableOfContents } from '@/components/TableOfContents'
 import Sponsors, { headings } from './sponsors.mdx'
 import { tiers, SponsorTiers } from './SponsorTiers'
 
-const sponsorHeadings = tiers.map((tier) => ({
+const sponsorHeadings: MDXHeadings = tiers.map((tier) => ({
   id: tier.title.toLowerCase(),
   text: tier.title,
   level: 3,

--- a/apps/site/app/(site)/sponsors/sponsors.mdx
+++ b/apps/site/app/(site)/sponsors/sponsors.mdx
@@ -25,3 +25,7 @@ Your support enables renoun to continue shipping great features like the followi
 - **Full Customization**
 
 Learn more about renoun features in the [Introduction](/docs/introduction) guide.
+
+## Sponsors
+
+Thank you to the following sponsors for their continued support of renoun. If you are not able to financially support renoun, please consider starring the [repository on GitHub](https://github.com/souporserious/renoun).

--- a/packages/renoun/package.json
+++ b/packages/renoun/package.json
@@ -179,6 +179,7 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "restyle": "catalog:",
+    "server-only": "0.0.1",
     "ts-morph": "catalog:",
     "unified": "catalog:",
     "unist-util-visit": "^5.0.0",

--- a/packages/renoun/src/components/Sponsors.mdx
+++ b/packages/renoun/src/components/Sponsors.mdx
@@ -1,0 +1,16 @@
+## Rendering GitHub Sponsors
+
+This component **requires a GitHub Personal Access Token** to fetch your sponsors from the GitHub GraphQL API. It runs only on the server and the token is never exposed to the client.
+
+### 1. Create a token
+
+Use a **Personal Access Token (classic)** with the required scope of `read:user`. You can create a token here: https://github.com/settings/tokens/new.
+
+### 2. Add the environment variable
+
+Configure the **`GITHUB_SPONSORS_TOKEN`** environment variable in your hosting provider:
+
+- **Vercel:** Project → Settings → Environment Variables
+- **Netlify:** Site configuration → Environment variables
+- **Amplify:** App settings → Environment variables
+- **Other:** See the documentation for your hosting provider.

--- a/packages/renoun/src/components/Sponsors.tsx
+++ b/packages/renoun/src/components/Sponsors.tsx
@@ -7,14 +7,12 @@ interface SponsorEntity {
 }
 
 interface Sponsor {
-  privacyLevel: 'PUBLIC' | 'PRIVATE'
   createdAt: string
-  tierSelectedAt: string | null
   sponsorEntity: SponsorEntity | null
   tier: {
-    name: string
     monthlyPriceInCents: number
   }
+  tierSelectedAt: string | null
 }
 
 interface MaintainerSponsor {
@@ -36,14 +34,16 @@ const AVATAR_MIN = 64
 const AVATAR_MAX = 512
 
 /** Clamp and sanitize avatar size. */
-function parseAvatarSize(number: number): number {
-  const value = Math.floor(Number.isFinite(number) ? number : AVATAR_MIN)
-  return Math.max(AVATAR_MIN, Math.min(AVATAR_MAX, value))
+function parseAvatarSize(sizeInPixels: number): number {
+  const clampedInput = Math.floor(
+    Number.isFinite(sizeInPixels) ? sizeInPixels : AVATAR_MIN
+  )
+  return Math.max(AVATAR_MIN, Math.min(AVATAR_MAX, clampedInput))
 }
 
 /** Builds a string of avatar fields for the given sizes. */
-function buildAvatarFields(sizes: readonly number[]) {
-  return sizes
+function buildSanitizedAvatarFields(avatarSizes: readonly number[]) {
+  return avatarSizes
     .map((size) => {
       const sanitizedSize = parseAvatarSize(size)
       return `avatar_${sanitizedSize}: avatarUrl(size: ${sanitizedSize})`
@@ -66,20 +66,67 @@ function hintForStatus(status: number): string {
   }
 }
 
-/** Fetches GitHub sponsors for the authenticated user. */
-async function fetchSponsors(
-  options: FetchSponsorsOptions & { avatarSizes: readonly number[] }
-) {
+/** Build the public checkout URL for a tier. */
+function buildTierCheckoutUrl(login: string, tierId: string): string {
+  return `https://github.com/sponsors/${login}/sponsorships?tier_id=${encodeURIComponent(
+    tierId
+  )}`
+}
+
+type TierInput<Data extends object> = {
+  /** The title of the tier defined in the GitHub Sponsors settings. */
+  title: string
+
+  /** Desired avatar size in pixels. If omitted, a default value based on the tier index is used. */
+  avatarSize?: number
+
+  /** The numeric GitHub Sponsors `tier_id` to link directly to. This will skip scraping for this tier. */
+  tierId?: string | number
+} & Data
+
+type TierResolved<Data extends object> = {
+  /** The title of the tier defined in the GitHub Sponsors settings. */
+  title: string
+
+  /** The minimum amount of money this tier is worth in USD. */
+  minAmount: number
+
+  /** A direct link to the GitHub checkout page for this tier. */
+  href: string
+
+  /** The sponsors for this tier. */
+  sponsors: PublicSponsor[]
+} & Data
+
+/** Fetches sponsors and groups them by tier. */
+type TierWithAmount<Data extends object> = TierInput<Data> & { amount: number }
+
+/** Single network call: fetch sponsors + sponsorable login + map tier HTML → closest tier_id link. */
+async function fetchSponsorsAndTierLinks(
+  options: FetchSponsorsOptions & {
+    avatarSizes: readonly number[]
+    manualTierIds?: ReadonlyMap<string, string>
+  }
+): Promise<{
+  hrefByTitle: Map<string, string>
+  sponsors: MaintainerSponsor[]
+  defaultHref: string
+}> {
   const token = process.env['GITHUB_SPONSORS_TOKEN']
 
   if (!token) {
-    // Skip erroring in Vercel and Netlify preview deployments
+    // Skip erroring in Vercel/Netlify previews
     if (
       process.env['VERCEL_ENV'] === 'preview' ||
       process.env['CONTEXT'] === 'deploy-preview' ||
       process.env['CONTEXT'] === 'branch-deploy'
     ) {
-      return [] as MaintainerSponsor[]
+      // Without a token, we don't know the login. Default to generic sponsors page.
+      return {
+        hrefByTitle: new Map(),
+        sponsors: [],
+        defaultHref: 'https://github.com/sponsors',
+      }
     }
 
     throw new Error(
@@ -87,25 +134,43 @@ async function fetchSponsors(
     )
   }
 
-  const variables = {
+  const graphqlVariables = {
     first: Math.max(1, Math.min(100, Math.floor(options.amount))),
   }
-  const avatarSizes = options.avatarSizes
-  const query = `
+
+  const graphqlQuery = `
     query($first: Int!) {
       viewer {
-        sponsorshipsAsMaintainer(first: $first) {
+        login
+        sponsorsListing {
+          tiers(first: 20) {
+            nodes {
+              name
+              description
+              descriptionHTML
+              isOneTime
+              monthlyPriceInCents
+              adminInfo {
+                isPublished
+                isRetired
+              }
+            }
+          }
+        }
+        sponsorshipsAsMaintainer(
+          first: $first
+          activeOnly: true
+          includePrivate: false
+        ) {
           nodes {
             createdAt
-            privacyLevel
             sponsorEntity {
               ... on User {
                 username: login
-                ${buildAvatarFields(avatarSizes)}
+                ${buildSanitizedAvatarFields(options.avatarSizes)}
               }
             }
             tier {
-              name
               monthlyPriceInCents
             }
             tierSelectedAt
@@ -114,28 +179,31 @@ async function fetchSponsors(
       }
     }
   `
-  const response = await fetch('https://api.github.com/graphql', {
+
+  const graphqlResponse = await fetch('https://api.github.com/graphql', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
       'User-Agent': 'renoun',
     },
-    body: JSON.stringify({ query, variables }),
+    body: JSON.stringify({ query: graphqlQuery, variables: graphqlVariables }),
   })
 
-  if (!response.ok) {
+  if (!graphqlResponse.ok) {
     throw new Error(
-      `[renoun] GitHub Sponsors request failed (${response.status}). ${hintForStatus(response.status)}`
+      `[renoun] GitHub Sponsors request failed (${graphqlResponse.status}). ${hintForStatus(graphqlResponse.status)}`
     )
   }
 
-  const json = await response.json()
+  const graphqlResponseJson = await graphqlResponse.json()
 
-  if (json.errors) {
+  if (graphqlResponseJson.errors) {
     if (process.env['NODE_ENV'] === 'development') {
       throw new Error(
-        `[renoun] GitHub Sponsors GraphQL request failed with the following errors: ${JSON.stringify(json.errors)}`
+        `[renoun] GitHub Sponsors GraphQL request failed with the following errors: ${JSON.stringify(
+          graphqlResponseJson.errors
+        )}`
       )
     } else {
       throw new Error(
@@ -144,24 +212,41 @@ async function fetchSponsors(
     }
   }
 
-  const nodes = json.data.viewer.sponsorshipsAsMaintainer.nodes as Sponsor[]
+  const viewer = graphqlResponseJson.data.viewer as {
+    login: string
+    sponsorsListing: {
+      tiers: {
+        nodes: Array<{
+          id: string
+          name: string
+          descriptionHTML: string
+          isOneTime: boolean
+          monthlyPriceInCents: number
+          adminInfo?: {
+            isPublished: boolean
+            isRetired: boolean
+          }
+        }>
+      }
+    } | null
+    sponsorshipsAsMaintainer: {
+      nodes: Sponsor[]
+    }
+  }
+
   const publicSponsors: MaintainerSponsor[] = []
 
-  for (const sponsor of nodes) {
-    if (sponsor.privacyLevel !== 'PUBLIC') {
-      continue
-    }
-
+  for (const sponsor of viewer.sponsorshipsAsMaintainer.nodes) {
     if (!sponsor.sponsorEntity) {
       continue
     }
 
     const entity: SponsorEntity = { username: sponsor.sponsorEntity.username }
 
-    for (const key of Object.keys(sponsor.sponsorEntity)) {
-      if (key.startsWith('avatar_')) {
+    for (const sponsorEntityKey of Object.keys(sponsor.sponsorEntity)) {
+      if (sponsorEntityKey.startsWith('avatar_')) {
         // @ts-expect-error
-        entity[key] = sponsor.sponsorEntity[key]
+        entity[sponsorEntityKey] = sponsor.sponsorEntity[sponsorEntityKey]
       }
     }
 
@@ -172,24 +257,128 @@ async function fetchSponsors(
     })
   }
 
-  return publicSponsors
+  // Build hrefs for published, non-retired monthly tiers.
+  const hrefByTitle = new Map<string, string>()
+  const hrefByAmount = new Map<number, string>()
+  const tierNodes = viewer.sponsorsListing?.tiers?.nodes ?? []
+
+  // Skip scraping if all relevant tiers supplied
+  const relevantTierNodes = tierNodes.filter((tierNode) => {
+    const isPublished = tierNode.adminInfo?.isPublished ?? true
+    const isRetired = tierNode.adminInfo?.isRetired ?? false
+    return isPublished && !isRetired && !tierNode.isOneTime
+  })
+
+  let manualMappedCount = 0
+
+  if (options.manualTierIds && options.manualTierIds.size > 0) {
+    for (const tierNode of relevantTierNodes) {
+      const manualTierId = options.manualTierIds.get(
+        tierNode.name.toLowerCase()
+      )
+      if (manualTierId) {
+        const linkHref = buildTierCheckoutUrl(
+          viewer.login,
+          String(manualTierId)
+        )
+        hrefByTitle.set(tierNode.name.toLowerCase(), linkHref)
+        hrefByAmount.set(tierNode.monthlyPriceInCents, linkHref)
+        manualMappedCount++
+      }
+    }
+
+    if (manualMappedCount === relevantTierNodes.length) {
+      const resolver = new Map<string, string>()
+      for (const [key, value] of hrefByTitle) {
+        resolver.set(key, value)
+      }
+      for (const [amountCents, value] of hrefByAmount) {
+        resolver.set(`$${amountCents}`, value)
+      }
+      return {
+        hrefByTitle: resolver,
+        sponsors: publicSponsors,
+        defaultHref: `https://github.com/sponsors/${viewer.login}`,
+      }
+    }
+  }
+
+  // Scrape public page for any missing tiers
+  let sponsorsPageHtml = ''
+
+  try {
+    const pageResponse = await fetch(
+      `https://github.com/sponsors/${viewer.login}`,
+      { headers: { 'User-Agent': 'renoun', Accept: 'text/html' } }
+    )
+    if (pageResponse.ok) {
+      sponsorsPageHtml = await pageResponse.text()
+    }
+  } catch {
+    // skip link mapping if this fails.
+  }
+
+  // scan all plain and percent-encoded tier_id anchors within return_to
+  const anchorRegex = /sponsorships(?:\?|%3[fF])tier_id(?:=|%3[dD])(\d+)/g
+  const anchorMatches: Array<{ tierId: string; index: number }> = []
+
+  if (sponsorsPageHtml) {
+    for (const match of sponsorsPageHtml.matchAll(anchorRegex)) {
+      anchorMatches.push({ tierId: match[1], index: match.index ?? 0 })
+    }
+  }
+
+  function nearestTierIdForSnippet(snippetHTML: string): string | undefined {
+    if (!sponsorsPageHtml || !anchorMatches.length) {
+      return undefined
+    }
+
+    const snippetIndex = sponsorsPageHtml.indexOf(snippetHTML)
+    if (snippetIndex === -1) {
+      return undefined
+    }
+
+    let bestMatch: { tierId: string; distance: number } | undefined
+
+    for (const anchor of anchorMatches) {
+      const distance = Math.abs(anchor.index - snippetIndex)
+      if (!bestMatch || distance < bestMatch.distance) {
+        bestMatch = { tierId: anchor.tierId, distance }
+      }
+    }
+
+    return bestMatch?.tierId
+  }
+
+  for (const tierNode of relevantTierNodes) {
+    // Skip tiers already set via manual map
+    if (hrefByTitle.has(tierNode.name.toLowerCase())) {
+      continue
+    }
+
+    const matchedTierId = nearestTierIdForSnippet(tierNode.descriptionHTML)
+
+    if (matchedTierId) {
+      const linkHref = buildTierCheckoutUrl(viewer.login, matchedTierId)
+      hrefByTitle.set(tierNode.name.toLowerCase(), linkHref)
+      hrefByAmount.set(tierNode.monthlyPriceInCents, linkHref)
+    }
+  }
+
+  const resolver = new Map<string, string>()
+  for (const [key, value] of hrefByTitle) {
+    resolver.set(key, value)
+  }
+  for (const [amountCents, value] of hrefByAmount) {
+    resolver.set(`$${amountCents}`, value)
+  }
+
+  return {
+    hrefByTitle: resolver,
+    sponsors: publicSponsors,
+    defaultHref: `https://github.com/sponsors/${viewer.login}`,
+  }
 }
-
-type TierInput<Data extends object> = {
-  /** The title of the tier defined in the GitHub Sponsors settings. */
-  title: string
-
-  /** Desired avatar size in pixels. If omitted, a default value based on the tier index is used. */
-  avatarSize?: number
-} & Data
-
-type TierResolved<Data extends object> = {
-  title: string
-  sponsors: PublicSponsor[]
-} & Data
-
-/** Fetches sponsors and groups them by tier. */
-type TierWithAmount<Data extends object> = TierInput<Data> & { amount: number }
 
 async function fetchSponsorTiers<const Data extends object>(
   tiers: ReadonlyArray<TierWithAmount<Data>>,
@@ -201,78 +390,109 @@ async function fetchSponsorTiers<const Data extends object>(
       data: {
         ...data,
         avatarSize: parseAvatarSize(
-          data.avatarSize ?? AVATAR_MIN * (index + 1)
+          (data as TierInput<Data>).avatarSize ?? AVATAR_MIN * (index + 1)
         ),
       },
     }))
     .sort((a, b) => a.minAmount - b.minAmount)
+
   const avatarSizes = Array.from(
     new Set(tierList.map((tier) => tier.data.avatarSize))
   ).sort((a, b) => a - b)
-  const sponsors = await fetchSponsors({ ...options, avatarSizes })
+
+  // Build manual tierId map keyed by lower-cased title.
+  const manualTierIds = new Map<string, string>()
+  for (const { data } of tierList) {
+    const maybeTierId = (data as TierInput<Data>).tierId
+    if (maybeTierId !== undefined && maybeTierId !== null) {
+      manualTierIds.set(
+        (data as TierInput<Data>).title.toLowerCase(),
+        String(maybeTierId)
+      )
+    }
+  }
+
+  const { sponsors, hrefByTitle, defaultHref } =
+    await fetchSponsorsAndTierLinks({
+      ...options,
+      avatarSizes,
+      manualTierIds: manualTierIds.size > 0 ? manualTierIds : undefined,
+    })
+
   const sponsorsByTitle = new Map<
     string,
     Array<PublicSponsor & { startedAt: number }>
   >()
 
   for (const { dollars, entity, startedAt } of sponsors) {
-    const index = tierList.findIndex((tier, tierIndex) => {
-      const next = tierList[tierIndex + 1]
-      return dollars >= tier.minAmount && (!next || dollars < next.minAmount)
+    const matchedTierIndex = tierList.findIndex((tier, tierIndex) => {
+      const nextTier = tierList[tierIndex + 1]
+      return (
+        dollars >= tier.minAmount && (!nextTier || dollars < nextTier.minAmount)
+      )
     })
-    if (index === -1) {
+
+    if (matchedTierIndex === -1) {
       continue
     }
 
-    const { title } = tierList[index].data
-    const sponsors = sponsorsByTitle.get(title) ?? []
-    const requestedSize = tierList[index].data.avatarSize
-    const exactKey = `avatar_${requestedSize}` as const
-    let avatarUrl = entity[exactKey]
+    const { title } = tierList[matchedTierIndex].data as TierInput<Data>
+    const listOfSponsors = sponsorsByTitle.get(title) ?? []
+    const requestedSize = tierList[matchedTierIndex].data.avatarSize
+    const exactAvatarKey = `avatar_${requestedSize}` as const
+    let avatarUrl = entity[exactAvatarKey]
 
-    // Fallback to the closest available size if the requested size is not available
+    // Fallback to closest available size
     if (!avatarUrl) {
-      const available = Object.keys(entity)
+      const availableSizes = Object.keys(entity)
         .filter((key) => key.startsWith('avatar_'))
         .map((key) => Number(key.replace('avatar_', '')))
-        .filter((number) => Number.isFinite(number)) as number[]
+        .filter((value) => Number.isFinite(value)) as number[]
 
-      if (available.length > 0) {
-        const closest = available.reduce((previous, current) =>
-          Math.abs(current - requestedSize) < Math.abs(previous - requestedSize)
-            ? current
-            : previous
+      if (availableSizes.length > 0) {
+        const closestAvailableSize = availableSizes.reduce(
+          (previous, current) =>
+            Math.abs(current - requestedSize) <
+            Math.abs(previous - requestedSize)
+              ? current
+              : previous
         )
-        avatarUrl = entity[`avatar_${closest}`]
+        avatarUrl = entity[`avatar_${closestAvailableSize}`]
       }
     }
 
     if (avatarUrl) {
-      sponsors.push({
-        username: entity.username,
-        avatarUrl,
-        startedAt,
-      })
+      listOfSponsors.push({ username: entity.username, avatarUrl, startedAt })
     }
 
-    sponsorsByTitle.set(title, sponsors)
+    sponsorsByTitle.set(title, listOfSponsors)
   }
 
-  return tierList.toReversed().map(({ data }) => {
-    const sponsorsList = sponsorsByTitle.get(data.title) ?? []
+  return tierList.toReversed().map(({ data, minAmount }) => {
+    const { title } = data as TierInput<Data>
+    const sponsorsList = sponsorsByTitle.get(title) ?? []
     const sortedSponsors = sponsorsList
       .slice()
       .sort((a, b) => a.startedAt - b.startedAt)
     const sanitizedSponsors: PublicSponsor[] = sortedSponsors.map(
-      ({ username, avatarUrl }) => ({
-        username,
-        avatarUrl,
-      })
+      ({ username, avatarUrl }) => ({ username, avatarUrl })
     )
-    const { avatarSize: _omitAvatarSize, ...rest } = data
+
+    // resolve href by case-insensitive title, or amount in cents
+    const href =
+      hrefByTitle.get(title.toLowerCase()) ??
+      hrefByTitle.get(`$${Math.round(minAmount * 100)}`) ??
+      defaultHref
+    const {
+      avatarSize: _omitSize,
+      tierId: _omitTierId,
+      ...rest
+    } = data as TierInput<Data>
+
     return {
-      ...(rest as unknown as Data & { title: string }),
+      ...(rest as Data & { title: string }),
       sponsors: sanitizedSponsors,
+      href,
     } as TierResolved<Data>
   })
 }
@@ -281,9 +501,6 @@ export interface SponsorsProps<Data extends object> {
   /** A list of tiers with the minimum monthly amount (in USD). */
   tiers: ReadonlyArray<TierWithAmount<Data>>
 
-  /** The number of sponsors to fetch. */
-  amount?: number
-
   /** Receives tiers (with your Data) and sanitized sponsors. */
   children: (tiers: Array<TierResolved<Data>>) => React.ReactNode
 }
@@ -291,9 +508,8 @@ export interface SponsorsProps<Data extends object> {
 /** Renders a list of GitHub sponsors grouped by tier. */
 export async function Sponsors<const Data extends object>({
   tiers,
-  amount = 100,
   children,
 }: SponsorsProps<Data>) {
-  const resolvedTiers = await fetchSponsorTiers<Data>(tiers, { amount })
+  const resolvedTiers = await fetchSponsorTiers<Data>(tiers, { amount: 100 })
   return children(resolvedTiers)
 }

--- a/packages/renoun/src/components/Sponsors.tsx
+++ b/packages/renoun/src/components/Sponsors.tsx
@@ -1,0 +1,299 @@
+import 'server-only'
+import React from 'react'
+
+interface SponsorEntity {
+  username: string
+  [key: `avatar_${number}`]: string | undefined
+}
+
+interface Sponsor {
+  privacyLevel: 'PUBLIC' | 'PRIVATE'
+  createdAt: string
+  tierSelectedAt: string | null
+  sponsorEntity: SponsorEntity | null
+  tier: {
+    name: string
+    monthlyPriceInCents: number
+  }
+}
+
+interface MaintainerSponsor {
+  entity: SponsorEntity
+  dollars: number
+  startedAt: number
+}
+
+interface PublicSponsor {
+  username: string
+  avatarUrl: string
+}
+
+interface FetchSponsorsOptions {
+  amount: number
+}
+
+const AVATAR_MIN = 64
+const AVATAR_MAX = 512
+
+/** Clamp and sanitize avatar size. */
+function parseAvatarSize(number: number): number {
+  const value = Math.floor(Number.isFinite(number) ? number : AVATAR_MIN)
+  return Math.max(AVATAR_MIN, Math.min(AVATAR_MAX, value))
+}
+
+/** Builds a string of avatar fields for the given sizes. */
+function buildAvatarFields(sizes: readonly number[]) {
+  return sizes
+    .map((size) => {
+      const sanitizedSize = parseAvatarSize(size)
+      return `avatar_${sanitizedSize}: avatarUrl(size: ${sanitizedSize})`
+    })
+    .join('\n')
+}
+
+function hintForStatus(status: number): string {
+  switch (status) {
+    case 401:
+      return 'Unauthorized — make sure GITHUB_SPONSORS_TOKEN exists in this environment and is valid and has not expired. Create a token here: https://github.com/settings/personal-access-tokens'
+    case 403:
+      return 'Forbidden — token lacks permission or an organization policy is blocking PAT access. Verify scopes/permissions or switch to a GitHub App / request org approval.'
+    case 404:
+      return 'Not found — check the GraphQL endpoint and that the token targets the correct account/org.'
+    case 429:
+      return 'Rate limited — wait for the reset window or cache results.'
+    default:
+      return 'Unexpected response from GitHub.'
+  }
+}
+
+/** Fetches GitHub sponsors for the authenticated user. */
+async function fetchSponsors(
+  options: FetchSponsorsOptions & { avatarSizes: readonly number[] }
+) {
+  const token = process.env['GITHUB_SPONSORS_TOKEN']
+
+  if (!token) {
+    // Skip erroring in Vercel and Netlify preview deployments
+    if (
+      process.env['VERCEL_ENV'] === 'preview' ||
+      process.env['CONTEXT'] === 'deploy-preview' ||
+      process.env['CONTEXT'] === 'branch-deploy'
+    ) {
+      return [] as MaintainerSponsor[]
+    }
+
+    throw new Error(
+      '[renoun] GITHUB_SPONSORS_TOKEN must be set when using the <Sponsors /> component.'
+    )
+  }
+
+  const variables = {
+    first: Math.max(1, Math.min(100, Math.floor(options.amount))),
+  }
+  const avatarSizes = options.avatarSizes
+  const query = `
+    query($first: Int!) {
+      viewer {
+        sponsorshipsAsMaintainer(first: $first) {
+          nodes {
+            createdAt
+            privacyLevel
+            sponsorEntity {
+              ... on User {
+                username: login
+                ${buildAvatarFields(avatarSizes)}
+              }
+            }
+            tier {
+              name
+              monthlyPriceInCents
+            }
+            tierSelectedAt
+          }
+        }
+      }
+    }
+  `
+  const response = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'renoun',
+    },
+    body: JSON.stringify({ query, variables }),
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `[renoun] GitHub Sponsors request failed (${response.status}). ${hintForStatus(response.status)}`
+    )
+  }
+
+  const json = await response.json()
+
+  if (json.errors) {
+    if (process.env['NODE_ENV'] === 'development') {
+      throw new Error(
+        `[renoun] GitHub Sponsors GraphQL request failed with the following errors: ${JSON.stringify(json.errors)}`
+      )
+    } else {
+      throw new Error(
+        `[renoun] GitHub Sponsors GraphQL request failed with errors.`
+      )
+    }
+  }
+
+  const nodes = json.data.viewer.sponsorshipsAsMaintainer.nodes as Sponsor[]
+  const publicSponsors: MaintainerSponsor[] = []
+
+  for (const sponsor of nodes) {
+    if (sponsor.privacyLevel !== 'PUBLIC') {
+      continue
+    }
+
+    if (!sponsor.sponsorEntity) {
+      continue
+    }
+
+    const entity: SponsorEntity = { username: sponsor.sponsorEntity.username }
+
+    for (const key of Object.keys(sponsor.sponsorEntity)) {
+      if (key.startsWith('avatar_')) {
+        // @ts-expect-error
+        entity[key] = sponsor.sponsorEntity[key]
+      }
+    }
+
+    publicSponsors.push({
+      entity,
+      dollars: sponsor.tier.monthlyPriceInCents / 100,
+      startedAt: Date.parse(sponsor.tierSelectedAt ?? sponsor.createdAt),
+    })
+  }
+
+  return publicSponsors
+}
+
+type TierInput<Data extends object> = {
+  /** The title of the tier defined in the GitHub Sponsors settings. */
+  title: string
+
+  /** Desired avatar size in pixels. If omitted, a default value based on the tier index is used. */
+  avatarSize?: number
+} & Data
+
+type TierResolved<Data extends object> = {
+  title: string
+  sponsors: PublicSponsor[]
+} & Data
+
+/** Fetches sponsors and groups them by tier. */
+type TierWithAmount<Data extends object> = TierInput<Data> & { amount: number }
+
+async function fetchSponsorTiers<const Data extends object>(
+  tiers: ReadonlyArray<TierWithAmount<Data>>,
+  options: FetchSponsorsOptions
+): Promise<Array<TierResolved<Data>>> {
+  const tierList = tiers
+    .map(({ amount, ...data }, index) => ({
+      minAmount: Number(amount),
+      data: {
+        ...data,
+        avatarSize: parseAvatarSize(
+          data.avatarSize ?? AVATAR_MIN * (index + 1)
+        ),
+      },
+    }))
+    .sort((a, b) => a.minAmount - b.minAmount)
+  const avatarSizes = Array.from(
+    new Set(tierList.map((tier) => tier.data.avatarSize))
+  ).sort((a, b) => a - b)
+  const sponsors = await fetchSponsors({ ...options, avatarSizes })
+  const sponsorsByTitle = new Map<
+    string,
+    Array<PublicSponsor & { startedAt: number }>
+  >()
+
+  for (const { dollars, entity, startedAt } of sponsors) {
+    const index = tierList.findIndex((tier, tierIndex) => {
+      const next = tierList[tierIndex + 1]
+      return dollars >= tier.minAmount && (!next || dollars < next.minAmount)
+    })
+    if (index === -1) {
+      continue
+    }
+
+    const { title } = tierList[index].data
+    const sponsors = sponsorsByTitle.get(title) ?? []
+    const requestedSize = tierList[index].data.avatarSize
+    const exactKey = `avatar_${requestedSize}` as const
+    let avatarUrl = entity[exactKey]
+
+    // Fallback to the closest available size if the requested size is not available
+    if (!avatarUrl) {
+      const available = Object.keys(entity)
+        .filter((key) => key.startsWith('avatar_'))
+        .map((key) => Number(key.replace('avatar_', '')))
+        .filter((number) => Number.isFinite(number)) as number[]
+
+      if (available.length > 0) {
+        const closest = available.reduce((previous, current) =>
+          Math.abs(current - requestedSize) < Math.abs(previous - requestedSize)
+            ? current
+            : previous
+        )
+        avatarUrl = entity[`avatar_${closest}`]
+      }
+    }
+
+    if (avatarUrl) {
+      sponsors.push({
+        username: entity.username,
+        avatarUrl,
+        startedAt,
+      })
+    }
+
+    sponsorsByTitle.set(title, sponsors)
+  }
+
+  return tierList.toReversed().map(({ data }) => {
+    const sponsorsList = sponsorsByTitle.get(data.title) ?? []
+    const sortedSponsors = sponsorsList
+      .slice()
+      .sort((a, b) => a.startedAt - b.startedAt)
+    const sanitizedSponsors: PublicSponsor[] = sortedSponsors.map(
+      ({ username, avatarUrl }) => ({
+        username,
+        avatarUrl,
+      })
+    )
+    const { avatarSize: _omitAvatarSize, ...rest } = data
+    return {
+      ...(rest as unknown as Data & { title: string }),
+      sponsors: sanitizedSponsors,
+    } as TierResolved<Data>
+  })
+}
+
+export interface SponsorsProps<Data extends object> {
+  /** A list of tiers with the minimum monthly amount (in USD). */
+  tiers: ReadonlyArray<TierWithAmount<Data>>
+
+  /** The number of sponsors to fetch. */
+  amount?: number
+
+  /** Receives tiers (with your Data) and sanitized sponsors. */
+  children: (tiers: Array<TierResolved<Data>>) => React.ReactNode
+}
+
+/** Renders a list of GitHub sponsors grouped by tier. */
+export async function Sponsors<const Data extends object>({
+  tiers,
+  amount = 100,
+  children,
+}: SponsorsProps<Data>) {
+  const resolvedTiers = await fetchSponsorTiers<Data>(tiers, { amount })
+  return children(resolvedTiers)
+}

--- a/packages/renoun/src/components/index.ts
+++ b/packages/renoun/src/components/index.ts
@@ -32,4 +32,5 @@ export {
   type ReferenceComponents,
 } from './Reference.js'
 export { Refresh } from './Refresh/index.js'
+export { Sponsors } from './Sponsors.js'
 export { ThemeProvider, ThemeStyles } from './Theme/index.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,6 +416,9 @@ importers:
       restyle:
         specifier: 'catalog:'
         version: 3.4.2(react@19.1.0)
+      server-only:
+        specifier: 0.0.1
+        version: 0.0.1
       ts-morph:
         specifier: 'catalog:'
         version: 26.0.0
@@ -3760,6 +3763,9 @@ packages:
     resolution: {integrity: sha512-qy1S34PJ/fcY8gjVGszDB3EXiPSk5FKhUa7tQe0UPRddxRidc2V6cNHPNewbE1D7MAkgLuWEt3Vw56vYy73tzQ==}
     engines: {node: '>= 14'}
     hasBin: true
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
@@ -8594,6 +8600,8 @@ snapshots:
       update-check: 1.5.4
     transitivePeerDependencies:
       - supports-color
+
+  server-only@0.0.1: {}
 
   shallowequal@1.1.0: {}
 


### PR DESCRIPTION
Adds a `Sponsors` component for rendering GitHub sponsors related to a specific user account. Note, this requires providing a `GITHUB_SPONSORS_TOKEN` with a `read:user` scope. The component will return formatted data for each sponsorship tier related to the user token:

```tsx
import { Sponsors } from "renoun/components";

export function SponsorTiers() {
  return (
    <Sponsors
      tiers={[
        { amount: 1000, title: "Gold", icon: "🏅" },
        { amount: 500, title: "Silver", icon: "🥈" },
        { amount: 100, title: "Bronze", icon: "🥉" },
      ]}
    >
      {(tiers) => (
        <section>
          {tiers.map((tier) => (
            <section key={tier.title}>
              <h3>
                {tier.icon} {tier.title}
              </h3>

              {tier.sponsors.length ? (
                <ul>
                  {tier.sponsors.map((sponsor) => (
                    <li key={sponsor.username}>
                      <a href={`https://github.com/${sponsor.username}`}>
                        <img src={sponsor.avatarUrl} alt={sponsor.username} />
                      </a>
                    </li>
                  ))}
                </ul>
              ) : (
                <a href={tier.href}>Sponsor {tier.title}</a>
              )}
            </section>
          ))}
        </section>
      )}
    </Sponsors>
  );
}
```