### PR TITLE
add root exports

### DIFF
--- a/.changeset/social-rules-take.md
+++ b/.changeset/social-rules-take.md
@@ -1,0 +1,5 @@
+---
+'renoun': minor
+---
+
+Adds root exports for the `renoun` package e.g. `import { CodeBlock } from 'renoun'`.

--- a/apps/site/app/(home)/QuickSteps.tsx
+++ b/apps/site/app/(home)/QuickSteps.tsx
@@ -1,4 +1,4 @@
-import type { CodeBlockProps } from 'renoun/components'
+import type { CodeBlockProps } from 'renoun'
 
 import { ButtonLink } from '@/components/ButtonLink'
 import { CodeBlock } from '@/components/CodeBlock'
@@ -8,7 +8,7 @@ const steps = [
   {
     title: 'Collect',
     content: `Collect, organize, and validate structured data using powerful file system utilities.`,
-    code: `import { Directory, withSchema } from 'renoun/file-system'
+    code: `import { Directory, withSchema } from 'renoun'
 import { z } from 'zod'
 
 export const posts = new Directory({
@@ -37,7 +37,7 @@ export const posts = new Directory({
   {
     title: 'Render',
     content: `Query and render your file system entries programmatically in your favorite framework.`,
-    code: `import { Directory } from 'renoun/file-system'
+    code: `import { Directory } from 'renoun'
 
 const posts = new Directory({ path: 'posts' })
 
@@ -58,7 +58,7 @@ async function Page({ slug }: { slug: string }) {
   {
     title: 'Personalize',
     content: `Select from a growing list of pre-built components to tailor your content and documentation to fit your unique needs and brand identity.`,
-    code: `import { CodeBlock, Tokens } from 'renoun/components'
+    code: `import { CodeBlock, Tokens } from 'renoun'
 
 function Page() {
   return (

--- a/apps/site/app/(home)/page.tsx
+++ b/apps/site/app/(home)/page.tsx
@@ -1,4 +1,4 @@
-import { CodeBlock, CodeInline } from 'renoun/components'
+import { CodeInline } from 'renoun'
 
 import { ButtonLink } from '@/components/ButtonLink'
 import { Text } from '@/components/Text'

--- a/apps/site/app/(site)/components/[...slug]/page.tsx
+++ b/apps/site/app/(site)/components/[...slug]/page.tsx
@@ -1,13 +1,14 @@
 import {
+  CodeBlock,
+  Tokens,
   isFile,
   isDirectory,
   FileNotFoundError,
   ModuleExportNotFoundError,
   type JavaScriptFile,
   type JavaScriptModuleExport,
-} from 'renoun/file-system'
-import { CodeBlock, Tokens } from 'renoun/components'
-import type { MDXHeadings } from 'renoun/mdx'
+  type MDXHeadings,
+} from 'renoun'
 import { GeistMono } from 'geist/font/mono'
 import { References } from '@/components/Reference'
 

--- a/apps/site/app/(site)/sponsors/SponsorTiers.tsx
+++ b/apps/site/app/(site)/sponsors/SponsorTiers.tsx
@@ -1,4 +1,4 @@
-import { Sponsors } from 'renoun/components'
+import { Sponsors } from 'renoun'
 
 export const tiers = [
   {

--- a/apps/site/app/(site)/sponsors/page.tsx
+++ b/apps/site/app/(site)/sponsors/page.tsx
@@ -1,4 +1,4 @@
-import type { MDXHeadings } from 'renoun/mdx'
+import type { MDXHeadings } from 'renoun'
 import { TableOfContents } from '@/components/TableOfContents'
 import Sponsors, { headings } from './sponsors.mdx'
 import { tiers, SponsorTiers } from './SponsorTiers'

--- a/apps/site/app/layout.tsx
+++ b/apps/site/app/layout.tsx
@@ -1,7 +1,7 @@
 import { Analytics } from '@vercel/analytics/react'
 import type { Metadata } from 'next'
 import { GeistSans } from 'geist/font/sans'
-import { Refresh } from 'renoun/components'
+import { Refresh } from 'renoun'
 
 export const metadata = {
   title: 'renoun - Elevate Your Design System Docs',

--- a/apps/site/collections/index.ts
+++ b/apps/site/collections/index.ts
@@ -1,4 +1,4 @@
-import { Collection } from 'renoun/file-system'
+import { Collection } from 'renoun'
 
 import { ComponentsDirectory } from './renoun'
 import { DocsDirectory, GuidesDirectory } from './site'

--- a/apps/site/collections/renoun.ts
+++ b/apps/site/collections/renoun.ts
@@ -4,8 +4,8 @@ import {
   isFile,
   withSchema,
   type FileSystemEntry,
-} from 'renoun/file-system'
-import type { MDXHeadings } from 'renoun/mdx'
+  type MDXHeadings,
+} from 'renoun'
 import { z } from 'zod'
 
 async function filterInternalExports(entry: FileSystemEntry<any>) {

--- a/apps/site/collections/site.ts
+++ b/apps/site/collections/site.ts
@@ -1,4 +1,4 @@
-import { Directory, isFile, withSchema } from 'renoun/file-system'
+import { Directory, isFile, withSchema } from 'renoun'
 import { z } from 'zod'
 
 const mdxSchema = {

--- a/apps/site/components/CodeBlock.tsx
+++ b/apps/site/components/CodeBlock.tsx
@@ -1,7 +1,4 @@
-import {
-  CodeBlock as DefaultCodeBlock,
-  type CodeBlockProps,
-} from 'renoun/components'
+import { CodeBlock as DefaultCodeBlock, type CodeBlockProps } from 'renoun'
 import { GeistMono } from 'geist/font/mono'
 
 export function CodeBlock(props: CodeBlockProps) {

--- a/apps/site/components/DocumentEntry.tsx
+++ b/apps/site/components/DocumentEntry.tsx
@@ -1,5 +1,4 @@
-import type { Collection, MDXFile } from 'renoun/file-system'
-import type { MDXHeadings } from 'renoun/mdx'
+import type { Collection, MDXFile, MDXHeadings } from 'renoun'
 
 import { SiblingLink } from './SiblingLink'
 import { TableOfContents } from './TableOfContents'

--- a/apps/site/components/MDX.tsx
+++ b/apps/site/components/MDX.tsx
@@ -1,5 +1,4 @@
-import { MDX as DefaultMDX } from 'renoun/components'
-import { remarkPlugins, rehypePlugins } from 'renoun/mdx'
+import { MDX as DefaultMDX, remarkPlugins, rehypePlugins } from 'renoun'
 
 import { MDXComponents } from '@/components/MDXComponents'
 

--- a/apps/site/components/MDXComponents.tsx
+++ b/apps/site/components/MDXComponents.tsx
@@ -1,5 +1,8 @@
-import { CodeInline, PackageInstall } from 'renoun/components'
-import type { MDXComponents as MDXComponentsType } from 'renoun/mdx'
+import {
+  CodeInline,
+  PackageInstall,
+  type MDXComponents as MDXComponentsType,
+} from 'renoun'
 import { GeistMono } from 'geist/font/mono'
 
 import { Card } from './Card'

--- a/apps/site/components/Markdown.tsx
+++ b/apps/site/components/Markdown.tsx
@@ -3,9 +3,10 @@ import {
   Markdown as DefaultMarkdown,
   parseCodeProps,
   parsePreProps,
+  rehypePlugins,
+  remarkPlugins,
   type MarkdownProps,
-} from 'renoun/components'
-import { rehypePlugins, remarkPlugins } from 'renoun/mdx'
+} from 'renoun'
 import { GeistMono } from 'geist/font/mono'
 
 import { CodeBlock } from './CodeBlock'

--- a/apps/site/components/Reference.tsx
+++ b/apps/site/components/Reference.tsx
@@ -1,9 +1,9 @@
-import type { JavaScriptModuleExport } from 'renoun/file-system'
 import {
   Reference as DefaultReference,
   type ReferenceProps,
   type ReferenceComponents,
-} from 'renoun/components'
+  type JavaScriptModuleExport,
+} from 'renoun'
 import { GeistMono } from 'geist/font/mono'
 import type { CSSObject } from 'restyle'
 

--- a/apps/site/components/SiblingLink.tsx
+++ b/apps/site/components/SiblingLink.tsx
@@ -4,7 +4,7 @@ import {
   isJavaScriptFile,
   ModuleExportNotFoundError,
   type FileSystemEntry,
-} from 'renoun/file-system'
+} from 'renoun'
 import { styled } from 'restyle'
 
 export async function SiblingLink({

--- a/apps/site/components/Sidebar/Sidebar.tsx
+++ b/apps/site/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import type { CSSObject } from 'restyle'
-import { GitProviderLink } from 'renoun/components'
+import { GitProviderLink } from 'renoun'
 
 import {
   DocsDirectory,

--- a/apps/site/components/Sidebar/TreeNavigation.tsx
+++ b/apps/site/components/Sidebar/TreeNavigation.tsx
@@ -5,7 +5,7 @@ import {
   isMDXFile,
   type Directory,
   type FileSystemEntry,
-} from 'renoun/file-system'
+} from 'renoun'
 import type { CSSObject } from 'restyle'
 
 import { SidebarLink } from './SidebarLink'

--- a/apps/site/components/SiteLayout.tsx
+++ b/apps/site/components/SiteLayout.tsx
@@ -1,4 +1,4 @@
-import { GitProviderLink } from 'renoun/components'
+import { GitProviderLink } from 'renoun'
 import { RenounLogo } from 'renoun/assets'
 
 import { NavigationLink } from './NavigationLink'

--- a/apps/site/components/TableOfContents.tsx
+++ b/apps/site/components/TableOfContents.tsx
@@ -1,8 +1,7 @@
 'use client'
 import { useId } from 'react'
 import type { CSSObject } from 'restyle'
-import type { MDXHeadings } from 'renoun/mdx'
-import { useSectionObserver } from 'renoun/hooks'
+import { useSectionObserver, type MDXHeadings } from 'renoun'
 
 import { ViewSource } from './ViewSource'
 

--- a/apps/site/docs/02.getting-started.mdx
+++ b/apps/site/docs/02.getting-started.mdx
@@ -1,4 +1,4 @@
-import { Reference } from 'renoun/components'
+import { Reference } from 'renoun'
 
 export const metadata = {
   title: 'Getting Started',
@@ -42,7 +42,7 @@ Prepending the renoun CLI ensures that the renoun process starts before your fra
 
 ## MDX Content
 
-The renoun toolkit helps with authoring MDX using the `renoun/mdx` package, allowing you to write content with a mix of Markdown and React components. The `renoun/mdx` package is not required to use, but provides a set of [useful plugins](/guides/mdx#pre-configured-plugins) to enhance your content.
+The renoun toolkit helps with authoring MDX using the `@renoun/mdx` package which is automatically installed with renoun, allowing you to write content with a mix of Markdown and React components. The `@renoun/mdx` package is not required to use, but provides a set of [useful plugins](/guides/mdx#pre-configured-plugins) to enhance your content.
 
 To start, create a new directory in your project called `posts` and add a new file called `build-a-button-component-in-react.mdx`:
 
@@ -86,7 +86,7 @@ We are using [YAML front matter](https://jekyllrb.com/docs/front-matter/) to def
 The `Directory` class is a core utility in renoun. This allows you to easily query and render files and directories within a file system. To create a list of blog posts, query all of the MDX files in the `posts` directory we created in the previous step:
 
 ```tsx
-import { Directory } from 'renoun/file-system'
+import { Directory } from 'renoun'
 
 const posts = new Directory({
   path: 'posts',
@@ -99,7 +99,7 @@ Now we can use the configured directory to render the contents of our MDX files 
 Create a new file in the `app/posts` directory called `[slug].tsx` and add the following:
 
 ```tsx
-import { Directory } from 'renoun/file-system'
+import { Directory } from 'renoun'
 
 const posts = new Directory({
   path: 'posts',
@@ -128,7 +128,7 @@ By default, the `Directory` class will load files using the MDX compiler. Howeve
 Use the `loader` option in the `Directory` constructor to assign a specific loader for each file type. In the `posts` directory, for instance, you can use a dynamic import as the loader to ensure that the MDX files are processed by the bundler:
 
 ```tsx highlightedLines="6-8"
-import { Directory } from 'renoun/file-system'
+import { Directory } from 'renoun'
 
 const posts = new Directory({
   path: 'posts',
@@ -150,7 +150,7 @@ Ensure that your bundler is configured to handle the file extension you are targ
 A [File System](/utilities/file-system) entry's `getPath` method is used to generate a route path for each entry in the directory. To generate a link to each post, map over the directory's entries using `getEntries` and then use the entry's `getPath` method to generate a list of links:
 
 ```tsx
-import { Directory } from 'renoun/file-system'
+import { Directory } from 'renoun'
 import Link from 'next/link'
 
 const posts = new Directory({
@@ -196,7 +196,7 @@ Alongside file loading, renoun can validate module exports to ensure that source
 Below is an example demonstrating how to validate a `metadata` object exported from a module using [Zod](https://zod.dev/):
 
 ```tsx path="posts.ts"
-import { Directory, withSchema } from 'renoun/file-system'
+import { Directory, withSchema } from 'renoun'
 import { z } from 'zod'
 
 export const posts = new Directory({
@@ -233,7 +233,7 @@ const { title, date, summary, tags } = metadata
 Now that we have a schema for the metadata, we can access it from the MDX file using the `getExportValue` method:
 
 ```tsx highlightedLines="29-30"
-import { Directory, withSchema } from 'renoun/file-system'
+import { Directory, withSchema } from 'renoun'
 import { z } from 'zod'
 
 export const posts = new Directory({
@@ -281,7 +281,7 @@ If you are using front matter, you can use the [remark-frontmatter](https://www.
 The renoun toolkit provides several built-in components to enhance your documentation like [`Reference`](/components/reference) and [`CodeBlock`](/components/code-block). For example, you can use the `Reference` component to document all exports from a module:
 
 ```mdx
-import { Reference } from 'renoun/components'
+import { Reference } from 'renoun'
 
 <Reference source="components/Card.tsx" />
 ```

--- a/apps/site/docs/03.configuration.mdx
+++ b/apps/site/docs/03.configuration.mdx
@@ -76,7 +76,7 @@ You can also specify multiple themes to be used, the first theme will be used as
 This requires using the `ThemeProvider` component that will inject the proper CSS Variables in the head of the document:
 
 ```tsx
-import { ThemeProvider } from 'renoun/components'
+import { ThemeProvider } from 'renoun'
 
 export default function RootLayout({
   children,
@@ -107,7 +107,7 @@ The `useThemePicker` hook can be used to build a select menu or toggle for choos
 
 ```tsx
 'use client'
-import { useThemePicker } from 'renoun/hooks'
+import { useThemePicker } from 'renoun'
 
 export function ThemePicker() {
   const [theme, setTheme] = useThemePicker()
@@ -126,7 +126,7 @@ export function ThemePicker() {
 If you are using another theming solution, you can use the `ThemeStyles` component directly to only load the CSS Variables for the theme:
 
 ```tsx
-import { ThemeStyles } from 'renoun/components'
+import { ThemeStyles } from 'renoun'
 
 export default function RootLayout({
   children,

--- a/apps/site/docs/Socials.tsx
+++ b/apps/site/docs/Socials.tsx
@@ -1,5 +1,6 @@
 import { styled } from 'restyle'
-import { GitProviderLogo } from 'renoun/components'
+import { GitProviderLogo } from 'renoun'
+
 import { Row } from '@/components/Row'
 
 const SocialLink = styled('a', {

--- a/apps/site/guides/01.mdx.mdx
+++ b/apps/site/guides/01.mdx.mdx
@@ -14,7 +14,7 @@ This guide will help you understand how to use MDX with renoun.
 The easiest way to get started using MDX with renoun is with the `MDX` component:
 
 ```tsx
-import { MDX } from 'renoun/components'
+import { MDX } from 'renoun'
 
 const content = `
 # Hello, world!
@@ -37,15 +37,15 @@ To learn how to configure MDX with Next.js, check out the [Next.js Guide](/guide
 
 ## Pre-configured Plugins
 
-The `renoun/mdx` import includes pre-configured plugins for both [remark](https://remark.js.org/) and [rehype](https://unifiedjs.com/), which are part the MDX process that parses and transforms MDX content.
+The `@renoun/mdx` package includes pre-configured plugins for both [remark](https://remark.js.org/) and [rehype](https://unifiedjs.com/), which are part the MDX process that parses and transforms MDX content.
 
-You can import these respective plugins and add them to your MDX configuration to extend the functionality of your MDX content.
+This package is automatically installed with renoun and can be imported directly from the `renoun` package. You can import the respective plugins and add them to your MDX configuration to extend the functionality of your MDX content:
 
 ```ts
-import { remarkPlugins, rehypePlugins } from 'renoun/mdx'
+import { remarkPlugins, rehypePlugins } from 'renoun'
 ```
 
-Here's a list of the plugins and their effects:
+The following is a list of the plugins and their effects:
 
 ### Community Plugins
 
@@ -176,7 +176,7 @@ const withMDX = createMDXPlugin({
 Or import and pass `CodeBlock` as a component to the MDX component:
 
 ```tsx
-import { CodeBlock } from 'renoun/components'
+import { CodeBlock } from 'renoun'
 import GettingStarted from './docs/getting-started.mdx'
 
 export default function Page() {
@@ -190,12 +190,12 @@ Exports the reading time metadata added by `rehype-infer-reading-time-meta` as a
 
 ## Applying plugins
 
-By default, the `MDX` component configures both the remark and rehype plugins from `renoun/mdx`. You can import and apply individual plugins to the `MDX` component or any other MDX configuration in your application.
+By default, the `MDX` component configures both the remark and rehype plugins from `@renoun/mdx`. You can import and apply individual plugins to the `MDX` component or any other MDX configuration in your application.
 
-We'll use the example from before and add the `renoun/mdx/rehype/add-code-block` plugin to the `MDX` component:
+We'll use the example from before and add the `@renoun/mdx/rehype/add-code-block` plugin to the `MDX` component:
 
 ```tsx
-import { MDX } from 'renoun/components'
+import { MDX } from 'renoun'
 import addCodeBlock from '@renoun/mdx/rehype/add-code-block'
 
 const content = `
@@ -209,11 +209,10 @@ export default function Page() {
 }
 ```
 
-Note, by overriding the `rehypePlugins` it will remove the default `renoun/mdx` rehype plugins. If you want to keep the default plugins, you can import and apply them to the `MDX` component and add your own plugins:
+Note, by overriding the `rehypePlugins` it will remove the default `@renoun/mdx` rehype plugins. If you want to keep the default plugins, you can import and apply them to the `MDX` component and add your own additional plugins:
 
 ```tsx
-import { MDX } from 'renoun/components'
-import { rehypePlugins, remarkPlugins } from 'renoun/mdx'
+import { MDX, rehypePlugins, remarkPlugins } from 'renoun'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
 

--- a/apps/site/guides/02.next.mdx
+++ b/apps/site/guides/02.next.mdx
@@ -82,13 +82,12 @@ export default {
 
 ## MDX (Optional)
 
-To enable writing MDX content in your Next.js application, we will use the [`@next/mdx`](https://github.com/vercel/next.js/tree/canary/packages/next-mdx) package. This package allows you to author MDX content in your Next.js project. Additionally, you can use the pre-configured `remarkPlugins` and `rehypePlugins` from `renoun/mdx`.
+To enable writing MDX content in your Next.js application, we will use the [`@next/mdx`](https://github.com/vercel/next.js/tree/canary/packages/next-mdx) package. This package allows you to author MDX content in your Next.js project. Additionally, you can use the pre-configured `remarkPlugins` and `rehypePlugins` from `renoun`.
 
 <Note>
 
 This step is optional and only necessary if you plan to use MDX in your
-project. Additionaly, you can skip adding the `renoun/mdx` package if you
-want to configure your own MDX plugins.
+project. Additionaly, you can skip adding the plugins from the `renoun` package if you want to configure your own MDX plugins.
 
 </Note>
 
@@ -96,11 +95,11 @@ First, install the Next.js MDX plugin:
 
 <PackageInstall packages={['@next/mdx']} />
 
-Now, add the plugin to your `next.config` file while optionally including the pre-configured `remarkPlugins` and `rehypePlugins` from `renoun/mdx`:
+Now, add the plugin to your `next.config` file while optionally including the pre-configured `remarkPlugins` and `rehypePlugins` from the `renoun` package:
 
 ```js path="03.next.config.mjs"
 import createMDXPlugin from '@next/mdx'
-import { remarkPlugins, rehypePlugins } from 'renoun/mdx'
+import { remarkPlugins, rehypePlugins } from 'renoun'
 
 const withMDX = createMDXPlugin({
   extension: /\.mdx?$/,
@@ -120,14 +119,14 @@ export default withMDX({
 Use the `CodeBlock` component to override the code fences in your project's `mdx-components.tsx` file:
 
 ```tsx path="02.mdx-components.tsx"
-import { CodeBlock } from 'renoun/components'
+import { CodeBlock } from 'renoun'
 
 export function useMDXComponents() {
   return { CodeBlock }
 }
 ```
 
-The `addCodeBlock` rehype plugin from `@renoun/mdx` replaces the code fence `pre` element with a `CodeBlock` component that will receive the code fence meta as props.
+The [`addCodeBlock` rehype plugin](/guides/mdx#rehype-add-code-block) from `@renoun/mdx` replaces the code fence `pre` element with a `CodeBlock` component that will receive the code fence meta as props.
 
 For example, the following code fence with meta props defined:
 
@@ -148,10 +147,10 @@ Roughly yields the following:
 
 ## Querying the File System
 
-The `Directory` utility in renoun lets you query and load files from your project’s file system. For example, to create a list of blog posts or documentation pages we can query all MDX files in a directory:
+The `Directory` utility in renoun lets you query and load files from your project's file system. For example, to create a list of blog posts or documentation pages we can query all MDX files in a directory:
 
 ```tsx
-import { Directory } from 'renoun/file-system'
+import { Directory } from 'renoun'
 
 const posts = new Directory({
   path: 'posts',
@@ -165,7 +164,7 @@ const posts = new Directory({
 Next, we can use the `Directory` instance to render the contents of our MDX files:
 
 ```tsx
-import { Directory } from 'renoun/file-system'
+import { Directory } from 'renoun'
 
 const posts = new Directory({
   path: 'posts',
@@ -192,10 +191,10 @@ This will create a collection of all MDX files in the `posts` directory and rend
 
 ### Generating Links
 
-A directory entry’s `getPath` method can generate a route path for each entry. For example, to generate a link to each post, you can iterate over the entries and use the entry’s `getPath` method:
+A directory entry's `getPath` method can generate a route path for each entry. For example, to generate a link to each post, you can iterate over the entries and use the entry's `getPath` method:
 
 ```tsx
-import { Directory } from 'renoun/file-system'
+import { Directory } from 'renoun'
 import Link from 'next/link'
 
 const posts = new Directory({
@@ -228,7 +227,7 @@ export default async function Page() {
 }
 ```
 
-Collections are not limited to MDX files and can be used with _any file type_.
+Directories are not limited to MDX files and can be used with _any file type_.
 
 ## Start
 

--- a/apps/site/guides/04.zod.mdx
+++ b/apps/site/guides/04.zod.mdx
@@ -6,7 +6,7 @@ export const metadata = {
 }
 
 ```ts
-import { Directory, withSchema } from 'renoun/file-system'
+import { Directory, withSchema } from 'renoun'
 import { z } from 'zod'
 
 const frontmatterSchema = z.object({
@@ -30,7 +30,7 @@ const posts = new Directory({
 
 ## Introduction
 
-In this guide, we'll walk through how to use [Zod](https://zod.dev/) to add schema validation to your file system. Using Valibot ensures that your targeted files conform to an expected structure, providing type safety and validation.
+In this guide, we'll walk through how to use [Zod](https://zod.dev/) to add schema validation to your file system. Using Zod ensures that your targeted files conform to an expected structure, providing type safety and validation.
 
 ### Before You Begin
 
@@ -66,7 +66,7 @@ const frontmatterSchema = z.object({
 We can now apply the Zod `frontmatterSchema` to your `Directory` using the `withSchema` helper:
 
 ```ts highlightedLines="1,11-20"
-import { Directory, withSchema } from 'renoun/file-system'
+import { Directory, withSchema } from 'renoun'
 import { z } from 'zod'
 
 const frontmatterSchema = z.object({

--- a/apps/site/guides/05.valibot.mdx
+++ b/apps/site/guides/05.valibot.mdx
@@ -6,7 +6,7 @@ export const metadata = {
 }
 
 ```ts
-import { Directory, withSchema } from 'renoun/file-system'
+import { Directory, withSchema } from 'renoun'
 import * as v from 'valibot'
 
 const frontmatterSchema = v.object({
@@ -66,7 +66,7 @@ const frontmatterSchema = v.object({
 We can now apply the Valibot `frontmatterSchema` to your collection using the `schema` option in the `collection` utility:
 
 ```ts highlightedLines="1,11-20"
-import { Directory, withSchema } from 'renoun/file-system'
+import { Directory, withSchema } from 'renoun'
 import * as v from 'valibot'
 
 const frontmatterSchema = v.object({

--- a/apps/site/mdx.d.ts
+++ b/apps/site/mdx.d.ts
@@ -1,3 +1,3 @@
 declare module '*.mdx' {
-  export const headings: import('renoun/mdx').MDXHeadings
+  export const headings: import('renoun').MDXHeadings
 }

--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -1,5 +1,5 @@
 import createMDXPlugin from '@next/mdx'
-import { remarkPlugins, rehypePlugins } from 'renoun/mdx'
+import { remarkPlugins, rehypePlugins } from 'renoun'
 
 const withMDX = createMDXPlugin({
   extension: /\.mdx?$/,

--- a/examples/blog/app/layout.tsx
+++ b/examples/blog/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { Refresh } from 'renoun/components'
+import { Refresh } from 'renoun'
 import './layout.css'
 
 export const metadata: Metadata = {

--- a/examples/blog/collections.ts
+++ b/examples/blog/collections.ts
@@ -1,4 +1,4 @@
-import { Directory, withSchema } from 'renoun/file-system'
+import { Directory, withSchema } from 'renoun'
 import { z } from 'zod'
 
 export const posts = new Directory({

--- a/examples/blog/tsconfig.json
+++ b/examples/blog/tsconfig.json
@@ -8,7 +8,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,

--- a/examples/design-system/app/components/[slug]/page.tsx
+++ b/examples/design-system/app/components/[slug]/page.tsx
@@ -1,11 +1,11 @@
-import { Reference } from 'renoun/components'
 import {
+  Reference,
   isFile,
   isDirectory,
   FileNotFoundError,
   type FileSystemEntry,
   type JavaScriptModuleExport,
-} from 'renoun/file-system'
+} from 'renoun'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 

--- a/examples/design-system/app/components/page.tsx
+++ b/examples/design-system/app/components/page.tsx
@@ -1,4 +1,4 @@
-import type { FileSystemEntry } from 'renoun/file-system'
+import type { FileSystemEntry } from 'renoun'
 import { styled } from 'restyle'
 import Link from 'next/link'
 

--- a/examples/design-system/app/layout.tsx
+++ b/examples/design-system/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
-import { Refresh, ThemeProvider } from 'renoun/components'
 import Link from 'next/link'
+import { Refresh, ThemeProvider } from 'renoun'
 
 import './layout.css'
 

--- a/examples/design-system/collections.ts
+++ b/examples/design-system/collections.ts
@@ -1,4 +1,4 @@
-import { Directory } from 'renoun/file-system'
+import { Directory } from 'renoun'
 
 export const ComponentsCollection = new Directory({
   path: 'components',

--- a/examples/design-system/mdx-components.tsx
+++ b/examples/design-system/mdx-components.tsx
@@ -1,5 +1,4 @@
-import { CodeBlock, parsePreProps } from 'renoun/components'
-import type { MDXComponents } from 'renoun/mdx'
+import { CodeBlock, parsePreProps, type MDXComponents } from 'renoun'
 
 export function useMDXComponents() {
   return {

--- a/examples/design-system/tsconfig.json
+++ b/examples/design-system/tsconfig.json
@@ -8,7 +8,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,

--- a/examples/docs/app/layout.tsx
+++ b/examples/docs/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
-import { Refresh } from 'renoun/components'
+import { Refresh } from 'renoun'
 import { routes } from '@/collections'
 import { SiblingLinks } from '@/ui/SiblingLinks'
 import { Sidebar } from '@/ui/Sidebar'

--- a/examples/docs/collections.ts
+++ b/examples/docs/collections.ts
@@ -1,4 +1,4 @@
-import { Directory, resolveFileFromEntry, withSchema } from 'renoun/file-system'
+import { Directory, resolveFileFromEntry, withSchema } from 'renoun'
 import { z } from 'zod'
 
 export const docs = new Directory({

--- a/examples/docs/mdx-components.tsx
+++ b/examples/docs/mdx-components.tsx
@@ -1,5 +1,4 @@
-import { CodeBlock } from 'renoun/components'
-import type { MDXComponents } from 'renoun/mdx'
+import { CodeBlock, type MDXComponents } from 'renoun'
 
 import { Accordion } from '@/ui/Accordion'
 import { Card } from '@/ui/Card'

--- a/examples/docs/ui/TreeNavigation.tsx
+++ b/examples/docs/ui/TreeNavigation.tsx
@@ -5,7 +5,7 @@ import {
   isMDXFile,
   type Directory,
   type FileSystemEntry,
-} from 'renoun/file-system'
+} from 'renoun'
 
 import { SidebarLink } from './SidebarLink'
 import * as SidebarCollapse from './SidebarCollapse'

--- a/packages/renoun/package.json
+++ b/packages/renoun/package.json
@@ -34,10 +34,19 @@
     "renoun": "./dist/cli/index.js"
   },
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "imports": {
     "#fixtures/*": "./fixtures/*"
   },
   "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "react-server": "./dist/index.server.js",
+      "browser": "./dist/index.client.js",
+      "node": "./dist/index.client.js",
+      "default": "./dist/index.js"
+    },
     "./assets": {
       "types": "./dist/assets/index.d.ts",
       "import": "./dist/assets/index.js",
@@ -99,46 +108,6 @@
       "default": "./dist/utils/index.js"
     }
   },
-  "typesVersions": {
-    "*": {
-      "assets": [
-        "./dist/assets/index.d.ts"
-      ],
-      "components": [
-        "./dist/components/index.d.ts"
-      ],
-      "components/*": [
-        "./dist/components/*.d.ts"
-      ],
-      "file-system": [
-        "./dist/file-system/index.d.ts"
-      ],
-      "grammars": [
-        "./dist/grammars/index.d.ts"
-      ],
-      "hooks": [
-        "./dist/hooks/index.d.ts"
-      ],
-      "hooks/*": [
-        "./dist/hooks/*.d.ts"
-      ],
-      "mdx": [
-        "./dist/mdx/index.d.ts"
-      ],
-      "mdx/*": [
-        "./dist/mdx/*.d.ts"
-      ],
-      "project": [
-        "./dist/project/client.d.ts"
-      ],
-      "server": [
-        "./dist/project/server.d.ts"
-      ],
-      "utils": [
-        "./dist/utils/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "build": "tsc && chmod +x dist/cli/index.js",
     "dev": "tsc -w",
@@ -179,7 +148,6 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "restyle": "catalog:",
-    "server-only": "0.0.1",
     "ts-morph": "catalog:",
     "unified": "catalog:",
     "unist-util-visit": "^5.0.0",

--- a/packages/renoun/src/components/CodeBlock/examples/index.tsx
+++ b/packages/renoun/src/components/CodeBlock/examples/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { CodeBlock, LineNumbers, Tokens, Toolbar } from 'renoun/components'
+import { CodeBlock, LineNumbers, Tokens, Toolbar } from 'renoun'
 
 export function Basic() {
   return <CodeBlock language="ts">const beep = 'boop'</CodeBlock>

--- a/packages/renoun/src/components/Sponsors.tsx
+++ b/packages/renoun/src/components/Sponsors.tsx
@@ -1,4 +1,3 @@
-import 'server-only'
 import React from 'react'
 
 interface SponsorEntity {

--- a/packages/renoun/src/index.client.ts
+++ b/packages/renoun/src/index.client.ts
@@ -1,0 +1,2 @@
+export * from './mdx/index.js'
+export * from './hooks/index.js'

--- a/packages/renoun/src/index.server.ts
+++ b/packages/renoun/src/index.server.ts
@@ -1,0 +1,3 @@
+export * from './components/index.js'
+export * from './file-system/index.js'
+export * from './mdx/index.js'

--- a/packages/renoun/src/index.ts
+++ b/packages/renoun/src/index.ts
@@ -1,0 +1,4 @@
+export * from './components/index.js'
+export * from './file-system/index.js'
+export * from './hooks/index.js'
+export * from './mdx/index.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,9 +416,6 @@ importers:
       restyle:
         specifier: 'catalog:'
         version: 3.4.2(react@19.1.0)
-      server-only:
-        specifier: 0.0.1
-        version: 0.0.1
       ts-morph:
         specifier: 'catalog:'
         version: 26.0.0
@@ -3763,9 +3760,6 @@ packages:
     resolution: {integrity: sha512-qy1S34PJ/fcY8gjVGszDB3EXiPSk5FKhUa7tQe0UPRddxRidc2V6cNHPNewbE1D7MAkgLuWEt3Vw56vYy73tzQ==}
     engines: {node: '>= 14'}
     hasBin: true
-
-  server-only@0.0.1:
-    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
@@ -8600,8 +8594,6 @@ snapshots:
       update-check: 1.5.4
     transitivePeerDependencies:
       - supports-color
-
-  server-only@0.0.1: {}
 
   shallowequal@1.1.0: {}
 


### PR DESCRIPTION
Adds root exports for the `renoun` package e.g. `import { CodeBlock } from 'renoun'`.