### PR TITLE
fix missing vite bin file

### DIFF
--- a/.changeset/ready-mails-clap.md
+++ b/.changeset/ready-mails-clap.md
@@ -1,0 +1,5 @@
+---
+'renoun': patch
+---
+
+Fixes error when locating the vite bin file when using the renoun cli.

--- a/packages/renoun/src/cli/index.ts
+++ b/packages/renoun/src/cli/index.ts
@@ -2,7 +2,7 @@
 import { spawn } from 'node:child_process'
 import { createRequire } from 'node:module'
 import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 import { createServer } from '../project/server.js'
 import { getDebugLogger } from '../utils/debug.js'
@@ -43,9 +43,8 @@ function resolveFrameworkBinFile(framework: Framework): string {
     throw new Error(`Could not find "bin" for ${framework}`)
   }
 
-  return projectRequire.resolve(
-    `${framework}/${binRelativePath.replace(/^\.\//, '')}`
-  )
+  const packageJsonDirectory = dirname(packageJsonPath)
+  return join(packageJsonDirectory, binRelativePath.replace(/^\.\//, ''))
 }
 
 if (


### PR DESCRIPTION
Fixes error when locating the vite bin file when using the renoun cli.

closes #300