### PR TITLE
add TableOfContents component

### DIFF
--- a/.changeset/every-chicken-invite.md
+++ b/.changeset/every-chicken-invite.md
@@ -1,0 +1,29 @@
+---
+'renoun': minor
+---
+
+Adds a `TableOfContents` component to render a list of headings for a document. This can be used with the [headings MDX plugin](https://www.renoun.dev/guides/mdx#remark-add-headings) to generate a table of contents for a page.
+
+```tsx
+import { TableOfContents } from 'renoun'
+import Content, { headings } from './content.mdx'
+
+export default function Page() {
+  return (
+    <main
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1fr 16rem',
+        gap: '2rem',
+      }}
+    >
+      <article>
+        <Content />
+      </article>
+      <aside>
+        <TableOfContents items={headings} />
+      </aside>
+    </main>
+  )
+}
+```

--- a/apps/site/app/(site)/components/[...slug]/page.tsx
+++ b/apps/site/app/(site)/components/[...slug]/page.tsx
@@ -8,14 +8,13 @@ import {
   type MDXHeadings,
   Link,
 } from 'renoun'
-import { References } from '@/components/Reference'
 
 import { RootCollection, ComponentsDirectory } from '@/collections'
 import { CodePreview } from '@/components/CodePreview'
 import { MDX } from '@/components/MDX'
+import { References } from '@/components/Reference'
 import { SiblingLink } from '@/components/SiblingLink'
 import { TableOfContents } from '@/components/TableOfContents'
-import { ViewSource } from '@/components/ViewSource'
 
 export async function generateStaticParams() {
   const entries = await ComponentsDirectory.getEntries({ recursive: true })
@@ -300,10 +299,7 @@ export default async function Component({
         </div>
       </div>
 
-      <TableOfContents
-        headings={headings}
-        viewSource={<ViewSource source={componentEntry} />}
-      />
+      <TableOfContents headings={headings} entry={componentEntry} />
     </>
   )
 }

--- a/apps/site/app/(site)/hooks/[...slug]/page.tsx
+++ b/apps/site/app/(site)/hooks/[...slug]/page.tsx
@@ -8,11 +8,11 @@ import {
   type JavaScriptModuleExport,
   type MDXHeadings,
 } from 'renoun'
-import { References } from '@/components/Reference'
 
 import { RootCollection, HooksDirectory } from '@/collections'
 import { CodePreview } from '@/components/CodePreview'
 import { MDX } from '@/components/MDX'
+import { References } from '@/components/Reference'
 import { SiblingLink } from '@/components/SiblingLink'
 import { TableOfContents } from '@/components/TableOfContents'
 

--- a/apps/site/app/(site)/sponsors/page.tsx
+++ b/apps/site/app/(site)/sponsors/page.tsx
@@ -1,5 +1,4 @@
-import type { MDXHeadings } from 'renoun'
-import { TableOfContents } from '@/components/TableOfContents'
+import { TableOfContents, type MDXHeadings } from 'renoun'
 import Sponsors, { headings } from './sponsors.mdx'
 import { tiers, SponsorTiers } from './SponsorTiers'
 

--- a/apps/site/app/(site)/utilities/file-system/page.tsx
+++ b/apps/site/app/(site)/utilities/file-system/page.tsx
@@ -1,6 +1,6 @@
 import { FileSystemDirectory } from '@/collections'
-import { TableOfContents } from '@/components/TableOfContents'
 import { References } from '@/components/Reference'
+import { TableOfContents } from '@/components/TableOfContents'
 
 export default async function Page() {
   const sourceFile = await FileSystemDirectory.getFile('index', 'tsx')

--- a/apps/site/app/layout.tsx
+++ b/apps/site/app/layout.tsx
@@ -32,9 +32,6 @@ export default function RootLayout({
         />
         <link rel="stylesheet" href="/layout.css" precedence="medium" />
         <body className={GeistSans.className}>
-          <script
-            dangerouslySetInnerHTML={{ __html: tableOfContentsActiveState }}
-          />
           {children}
           <Analytics />
         </body>
@@ -42,38 +39,3 @@ export default function RootLayout({
     </RootProvider>
   )
 }
-
-const tableOfContentsActiveState = `
-const getVisibilityRatio = (element) => {
-  const rect = element.getBoundingClientRect();
-  const scrollTop = window.scrollY;
-  const scrollBottom = scrollTop + window.innerHeight;
-  const top = scrollTop + rect.top;
-  const bottom = scrollTop + rect.bottom;
-  const visibleTop = Math.max(scrollTop, top);
-  const visibleBottom = Math.min(scrollBottom, bottom);
-  return Math.max(0, visibleBottom - visibleTop) / (bottom - top);
-};
-let previousActiveSectionId = null;
-window.isSectionLinkActive = function (id) {
-  const section = document.getElementById(id);
-  if (!section) return;
-  const currentVisibility = getVisibilityRatio(section);
-  if (currentVisibility > 0) {
-    if (previousActiveSectionId) {
-      const previousSection = document.getElementById(previousActiveSectionId);
-      const previousVisibility = getVisibilityRatio(previousSection);
-      // Update active only if the current section is more visible
-      if (currentVisibility <= previousVisibility) {
-        return; // Keep the previous section active
-      }
-      const previousActiveLink = document.querySelector(\`[href="#\${previousActiveSectionId}"]\`);
-      if (previousActiveLink) {
-        previousActiveLink.classList.remove("active");
-      }
-    }
-    previousActiveSectionId = id;
-  }
-  document.currentScript.parentElement.classList.toggle("active", currentVisibility > 0);
-};
-`

--- a/apps/site/components/DocumentEntry.tsx
+++ b/apps/site/components/DocumentEntry.tsx
@@ -1,8 +1,7 @@
 import type { Collection, MDXFile, MDXHeadings } from 'renoun'
 
+import { TableOfContents } from '@/components/TableOfContents'
 import { SiblingLink } from './SiblingLink'
-import { TableOfContents } from './TableOfContents'
-import { ViewSource } from './ViewSource'
 
 export async function DocumentEntry({
   file,
@@ -95,10 +94,7 @@ export async function DocumentEntry({
       </div>
 
       {shouldRenderTableOfContents ? (
-        <TableOfContents
-          headings={headings}
-          viewSource={<ViewSource source={file} />}
-        />
+        <TableOfContents headings={headings} entry={file} />
       ) : null}
     </>
   )

--- a/apps/site/components/Sidebar/TreeNavigation.tsx
+++ b/apps/site/components/Sidebar/TreeNavigation.tsx
@@ -27,25 +27,19 @@ const components: Partial<NavigationComponents> = {
     </ul>
   ),
   List: ({ entry, children }) => {
-    let paddingLeft = '0'
-
-    if (isDirectory(entry)) {
-      const depth = entry.getDepth()
-      if (depth > 0) {
-        paddingLeft = `${depth}rem`
-      }
-    }
-
     return (
       <ul
+        style={{
+          '--depth': isDirectory(entry) ? entry.getDepth() : 0,
+        }}
         css={{
+          listStyle: 'none',
           fontSize: 'var(--font-size-body-2)',
           display: 'flex',
           flexDirection: 'column',
-          listStyle: 'none',
+          paddingLeft: '0.25rem',
           marginLeft: '0.25rem',
           borderLeft: '1px solid var(--color-separator)',
-          paddingLeft,
         }}
       >
         {children}
@@ -66,7 +60,15 @@ const components: Partial<NavigationComponents> = {
       label = await getFileLabel(entry)
     }
 
-    return <SidebarLink pathname={pathname} label={label} />
+    return (
+      <SidebarLink
+        pathname={pathname}
+        label={label}
+        css={{
+          paddingLeft: `calc(var(--depth) * 0.8rem)`,
+        }}
+      />
+    )
   },
 }
 

--- a/apps/site/components/ViewSource.tsx
+++ b/apps/site/components/ViewSource.tsx
@@ -9,7 +9,11 @@ export function ViewSource({
   css?: CSSObject
 }) {
   return (
-    <span
+    <Link
+      source={source}
+      variant="source"
+      target="_blank"
+      rel="noreferrer"
       css={{
         display: 'flex',
         alignItems: 'center',
@@ -24,9 +28,7 @@ export function ViewSource({
         ...css,
       }}
     >
-      <Link source={source} variant="source" target="_blank" rel="noreferrer">
-        View Source{' '}
-      </Link>
+      View Source
       <svg
         fill="none"
         width="1em"
@@ -42,6 +44,6 @@ export function ViewSource({
         <path d="M15 3h6v6" />
         <path d="M10 14L21 3" />
       </svg>
-    </span>
+    </Link>
   )
 }

--- a/packages/renoun/src/components/RootProvider.tsx
+++ b/packages/renoun/src/components/RootProvider.tsx
@@ -7,6 +7,7 @@ import { ServerConfigContext } from './Config/ServerConfigContext.js'
 import { defaultConfig } from './Config/default-config.js'
 import type { ConfigurationOptions, ThemeValue } from './Config/types.js'
 import { Refresh } from './Refresh'
+import { TableOfContentsScript } from './TableOfContents/TableOfContentsScript.js'
 import { ThemeProvider } from './Theme'
 
 type ThemeMap = Record<string, ThemeValue>
@@ -21,6 +22,9 @@ interface BaseProps
 
   /** Control whether to include the script for the `Command` component in the document head. */
   includeCommandScript?: boolean
+
+  /** Control whether to include the script for the `TableOfContents` component in the document head. */
+  includeTableOfContentsScript?: boolean
 
   /** The `html` element tree to render. */
   children: React.ReactNode
@@ -52,6 +56,7 @@ export function RootProvider<Theme extends ThemeValue | ThemeMap | undefined>({
   git,
   siteUrl,
   includeCommandScript = true,
+  includeTableOfContentsScript = true,
   includeThemeScript = true,
   nonce,
   ...restProps
@@ -132,6 +137,9 @@ export function RootProvider<Theme extends ThemeValue | ThemeMap | undefined>({
             defaultPackageManager={merged.defaultPackageManager}
             nonce={nonce}
           />
+        ) : null}
+        {includeTableOfContentsScript ? (
+          <TableOfContentsScript nonce={nonce} />
         ) : null}
         {typeof merged.theme === 'object' ? (
           <ThemeProvider

--- a/packages/renoun/src/components/SectionObserver/SectionObserver.tsx
+++ b/packages/renoun/src/components/SectionObserver/SectionObserver.tsx
@@ -1,0 +1,56 @@
+'use client'
+import React, { createContext, cloneElement, isValidElement } from 'react'
+
+import { useSectionObserver } from '../../hooks/use-section-observer.js'
+
+const SectionObserverContext = createContext<ReturnType<
+  typeof useSectionObserver
+> | null>(null)
+
+/**
+ * Hook to access the section observer context.
+ * @internal
+ */
+export function useContext() {
+  const context = React.useContext(SectionObserverContext)
+  if (!context) {
+    throw new Error(
+      '[renoun] SectionObserver.useContext must be used within a SectionObserver.Provider'
+    )
+  }
+  return context
+}
+
+/**
+ * Provides the section observer context to descendant components.
+ * @internal
+ */
+export function Provider({ children }: { children: React.ReactNode }) {
+  const sectionObserver = useSectionObserver()
+  return (
+    <SectionObserverContext value={sectionObserver}>
+      {children}
+    </SectionObserverContext>
+  )
+}
+
+/**
+ * A link that observes section visibility and updates its active state accordingly.
+ * @internal
+ */
+export function Link({
+  id,
+  children,
+}: {
+  id: string
+  children: React.ReactNode
+}) {
+  const sectionObserver = useContext()
+  const linkProps = sectionObserver.useLink(id)
+  return (
+    <>
+      {isValidElement(children) ? cloneElement(children, linkProps) : null}
+      <script>{`window.isSectionLinkActive?.('${id}')`}</script>
+    </>
+  )
+}

--- a/packages/renoun/src/components/SectionObserver/index.ts
+++ b/packages/renoun/src/components/SectionObserver/index.ts
@@ -1,0 +1,1 @@
+export * as SectionObserver from './SectionObserver.js'

--- a/packages/renoun/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/renoun/src/components/TableOfContents/TableOfContents.tsx
@@ -1,0 +1,132 @@
+import React, { useId } from 'react'
+import type { CSSObject } from 'restyle'
+
+import type { MDXHeadings } from '../../mdx/index.js'
+import { SectionObserver } from '../SectionObserver/index.js'
+
+type ElementProps<Tag extends keyof React.JSX.IntrinsicElements> =
+  React.JSX.IntrinsicElements[Tag] & { css?: CSSObject }
+
+type TableOfContentsComponent<
+  Tag extends keyof React.JSX.IntrinsicElements,
+  Props = {},
+> = React.ComponentType<ElementProps<Tag> & Props>
+
+export interface TableOfContentsComponents {
+  Root: TableOfContentsComponent<'nav'>
+  Title: TableOfContentsComponent<'h4'>
+  List: TableOfContentsComponent<'ol'>
+  Item: TableOfContentsComponent<'li'>
+  Link: TableOfContentsComponent<'a'>
+}
+
+export interface TableOfContentsProps {
+  /** The headings to display within the table of contents. */
+  headings: MDXHeadings
+
+  /** Override the default component renderers. */
+  components?: Partial<TableOfContentsComponents>
+
+  /** Optional content rendered after the heading links. */
+  children?: React.ReactNode
+}
+
+const defaultComponents: TableOfContentsComponents = {
+  Root: ({ children, ...props }) => <nav {...props}>{children}</nav>,
+  Title: ({ children, ...props }) => (
+    <h4 {...props}>{children ?? 'On this page'}</h4>
+  ),
+  List: ({ children, ...props }) => <ol {...props}>{children}</ol>,
+  Item: ({ children, ...props }) => <li {...props}>{children}</li>,
+  Link: ({ children, ...props }) => <a {...props}>{children}</a>,
+}
+
+export function TableOfContents({
+  headings,
+  components = {},
+  children,
+}: TableOfContentsProps) {
+  const id = useId()
+  const { Root, Title, List, Item, Link }: TableOfContentsComponents = {
+    ...defaultComponents,
+    ...components,
+  }
+  const filteredHeadings = headings.filter((heading) => heading.level > 1)
+
+  interface TableOfContentsItem {
+    id: string
+    level: number
+    title: React.ReactNode
+    children: TableOfContentsItem[]
+  }
+
+  const items: TableOfContentsItem[] = []
+  if (filteredHeadings.length > 0) {
+    const baseLevel = filteredHeadings[0].level
+    const parents: (TableOfContentsItem | undefined)[] = []
+
+    for (const heading of filteredHeadings) {
+      const depth = Math.max(0, heading.level - baseLevel)
+      const node: TableOfContentsItem = {
+        id: heading.id,
+        level: heading.level,
+        title: heading.children ?? heading.text,
+        children: [],
+      }
+
+      if (depth === 0) {
+        items.push(node)
+      } else {
+        // Prefer the exact parent at depth 1, otherwise fall back to the closest existing ancestor.
+        const parent =
+          parents[depth - 1] ?? parents.slice(0, depth).reverse().find(Boolean)
+        if (parent) {
+          parent.children.push(node)
+        } else {
+          items.push(node)
+        }
+      }
+
+      // Record this node as the current item at its depth and truncate deeper parents.
+      parents[depth] = node
+      parents.length = depth + 1
+    }
+  }
+
+  function renderItems(
+    items: TableOfContentsItem[],
+    level = 0
+  ): React.ReactNode {
+    if (items.length === 0) {
+      return null
+    }
+    return (
+      <List style={{ [String('--level')]: level }}>
+        {items.map((item) => (
+          <Item key={item.id}>
+            <SectionObserver.Link id={item.id}>
+              <Link>{item.title}</Link>
+            </SectionObserver.Link>
+            {item.children.length > 0
+              ? renderItems(item.children, level + 1)
+              : null}
+          </Item>
+        ))}
+      </List>
+    )
+  }
+
+  if (filteredHeadings.length === 0 && !children) {
+    return null
+  }
+
+  return (
+    <SectionObserver.Provider>
+      <Root aria-labelledby={id}>
+        <Title id={id} />
+        {renderItems(items)}
+        {children}
+      </Root>
+    </SectionObserver.Provider>
+  )
+}

--- a/packages/renoun/src/components/TableOfContents/TableOfContentsScript.tsx
+++ b/packages/renoun/src/components/TableOfContents/TableOfContentsScript.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+const tableOfContentsActiveState = `
+const getVisibilityRatio = (element) => {
+  const rect = element.getBoundingClientRect();
+  const scrollTop = window.scrollY;
+  const scrollBottom = scrollTop + window.innerHeight;
+  const top = scrollTop + rect.top;
+  const bottom = scrollTop + rect.bottom;
+  const visibleTop = Math.max(scrollTop, top);
+  const visibleBottom = Math.min(scrollBottom, bottom);
+  return Math.max(0, visibleBottom - visibleTop) / (bottom - top);
+};
+let previousActiveSectionId = null;
+window.isSectionLinkActive = function (id) {
+  const section = document.getElementById(id);
+  if (!section) return;
+  const currentVisibility = getVisibilityRatio(section);
+  if (currentVisibility > 0) {
+    if (previousActiveSectionId) {
+      const previousSection = document.getElementById(previousActiveSectionId);
+      const previousVisibility = getVisibilityRatio(previousSection);
+      if (currentVisibility <= previousVisibility) return;
+      const previousActiveLink = document.querySelector(\`[href="#\${previousActiveSectionId}"]\`);
+      if (previousActiveLink) previousActiveLink.classList.remove("active");
+    }
+    previousActiveSectionId = id;
+  }
+  document.currentScript.parentElement.classList.toggle("active", currentVisibility > 0);
+};
+`.trim()
+const source = `data:text/javascript;base64,${btoa(tableOfContentsActiveState)}`
+
+/**
+ * Global script for `TableOfContents`. Defines a `window.isSectionLinkActive` helper used by link inline scripts.
+ * @internal
+ */
+export function TableOfContentsScript({ nonce }: { nonce?: string }) {
+  return <script async nonce={nonce} src={source} />
+}

--- a/packages/renoun/src/components/TableOfContents/index.ts
+++ b/packages/renoun/src/components/TableOfContents/index.ts
@@ -1,0 +1,5 @@
+export {
+  TableOfContents,
+  type TableOfContentsProps,
+  type TableOfContentsComponents,
+} from './TableOfContents.js'

--- a/packages/renoun/src/components/index.ts
+++ b/packages/renoun/src/components/index.ts
@@ -34,6 +34,11 @@ export {
   type ReferenceComponents,
 } from './Reference.js'
 export {
+  TableOfContents,
+  type TableOfContentsProps,
+  type TableOfContentsComponents,
+} from './TableOfContents/index.js'
+export {
   Navigation,
   type NavigationProps,
   type NavigationComponents,

--- a/packages/renoun/src/hooks/use-section-observer.ts
+++ b/packages/renoun/src/hooks/use-section-observer.ts
@@ -127,16 +127,20 @@ export function useSectionObserver({
         }
       }, [activeId, id])
 
-      return [
-        store.getSnapshot() === null ? null : isActive,
-        {
-          href: `#${id}`,
-          onClick: (e: React.MouseEvent<HTMLAnchorElement>) => {
-            e.preventDefault()
-            scrollToSection(id)
-          },
-        } as const,
-      ] as const
+      const props: React.AnchorHTMLAttributes<HTMLAnchorElement> = {
+        href: `#${id}`,
+        suppressHydrationWarning: true,
+        onClick: (event: React.MouseEvent<HTMLAnchorElement>) => {
+          event.preventDefault()
+          scrollToSection(id)
+        },
+      }
+
+      if (store.getSnapshot() === null ? null : isActive) {
+        props['aria-current'] = 'location'
+      }
+
+      return props
     }
 
     return { scrollToSection, useSection, useLink }

--- a/packages/renoun/src/index.client.ts
+++ b/packages/renoun/src/index.client.ts
@@ -1,2 +1,3 @@
+export { TableOfContents } from './components/TableOfContents/TableOfContents.js'
 export * from './mdx/index.js'
 export * from './hooks/index.js'


### PR DESCRIPTION
Adds a `TableOfContents` component to render a list of headings for a document. This can be used with the [headings MDX plugin](https://www.renoun.dev/guides/mdx#remark-add-headings) to generate a table of contents for a page.

```tsx
import { TableOfContents } from 'renoun'
import Content, { headings } from './content.mdx'

export default function Page() {
  return (
    <main
      style={{
        display: 'grid',
        gridTemplateColumns: '1fr 16rem',
        gap: '2rem',
      }}
    >
      <article>
        <Content />
      </article>
      <aside>
        <TableOfContents items={headings} />
      </aside>
    </main>
  )
}
```
