### PR TITLE
add Script component

### DIFF
--- a/.changeset/gentle-crabs-throw.md
+++ b/.changeset/gentle-crabs-throw.md
@@ -1,0 +1,24 @@
+---
+'renoun': minor
+---
+
+Adds a `Script` component that lets you author a client-side script using a normal source file that is then injected into HTML either inline, deferred, or as a hoisted data URL. This is useful for small scripts like analytics snippets, theme preferences, feature flags, or bootstrapping navigation active states.
+
+```tsx path="app/page.tsx"
+import { Script } from 'renoun'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <head>
+        <Script>{import('./table-of-contents-script.ts')}</Script>
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+}
+```

--- a/packages/renoun/src/components/Script.mdx
+++ b/packages/renoun/src/components/Script.mdx
@@ -1,0 +1,135 @@
+A tiny helper that lets you author a client-side script using a normal source file that is then injected into HTML either **inline**, **deferred**, or **as a hoisted data URL**. This is useful for small scripts like analytics snippets, theme preferences, feature flags, or bootstrapping navigation active states.
+
+## Quick start
+
+```tsx path="app/page.tsx"
+import { Script } from 'renoun'
+
+export default function Page() {
+  return (
+    <>
+      {/* Hoist for earliest execution */}
+      <Script variant="hoist">{import('./table-of-contents-script.ts')}</Script>
+
+      {/* Or inline/defer (default) */}
+      <Script>{import('./analytics-script.ts')}</Script>
+    </>
+  )
+}
+```
+
+```ts path="table-of-contents-script.ts"
+// use types if you want
+declare global {
+  interface Window {
+    __TableOfContents__: {
+      register: (headingIds: string[]) => void
+    }
+  }
+}
+
+// default export MUST be a function
+export default function () {
+  // use client APIs
+  const headingIds = document.querySelectorAll('a[href^="#"]').forEach((a) => {
+    // ...
+  })
+  window.__TableOfContents__ = {
+    register: (ids) => {
+      //   ...
+    },
+  }
+}
+```
+
+## Authoring scripts
+
+Export a function. The component stringifies the function and hands it off to a React script element.
+
+```ts
+// ✅ Classic function
+export default function () {
+  // your script
+}
+
+// ✅ Arrow with a block body
+export default () => {
+  // your script
+}
+
+// ⚠️ Only a default export is supported
+export const initialize = () => {}
+```
+
+## How it works
+
+The helper stringifies the incoming module default function `Function.prototype.toString()` and hands the body of the function to a React `<script>` element.
+
+Hoisted scripts are marked `async` and run as soon as possible without blocking HTML parsing. The script is base64-encoded and set as a `data:` URL. This uses [React's special rendering behavior](https://react.dev/reference/react-dom/components/script#special-rendering-behavior) to hoist the script element to the head.
+
+## Variants
+
+### Deferred inline (default)
+
+### Variants
+
+```tsx allowErrors showErrors={false}
+<Script variant="defer">{import('./features/client-snippet.ts')}</Script>
+```
+
+Renders `<script defer>` with your code inline.
+
+### Inline, no defer
+
+```tsx allowErrors showErrors={false}
+<Script variant="inline">{import('./critical-inline.ts')}</Script>
+```
+
+Renders an inline `<script>` that runs as soon as parsed (blocking the parser). Use sparingly.
+
+### Hoisted data URL
+
+```tsx allowErrors showErrors={false}
+<Script variant="hoist">{import('./early.ts')}</Script>
+```
+
+Renders `<script async src="data:text/javascript;base64,…">` so the browser can execute as early as possible without blocking HTML parsing.
+
+## Security
+
+This component avoids `eval` and `dangerouslySetInnerHTML`. The risk is the same as any inline script. The flow looks like this:
+
+1. Await the `import()`.
+2. Take the module's `default` export (must be a function).
+3. `toString()` it, extract the body, place it as the `<script>` text (or base64 in a `data:` URL for `hoist` variant).
+
+<Note>
+
+It has the same risk profile as any inline script. Anything in that function runs with full page privileges.
+
+</Note>
+
+### Trust & origin
+
+Only import code you control. If an attacker can alter the imported module (user-writable path, unchecked generation, etc.) they get arbitrary script execution.
+
+### Variants & CSP
+
+- `defer` / `inline`: literal `<script>` body.
+- `hoist`: `<script async src="data:text/javascript;base64,…">` (needs `data:` in `script-src`).
+
+Provide a nonce (or hash) under CSP:
+
+```tsx allowErrors showErrors={false}
+<Script nonce={nonce}>{import('./snippet.ts')}</Script>
+```
+
+Inline/defer need a nonce or hash; hoist additionally needs `data:` allowed (or use defer). Prefer nonces over `'unsafe-inline'`.
+
+### XSS considerations
+
+HTML inside the function body isn't parsed as markup—it's just JS source—but **any attacker-controlled interpolation into that function becomes code**. Do not template untrusted input into the exported function.
+
+### Keep it small
+
+Hoisted base64 inflates HTML; reserve for tiny early snippets (theme, flags, analytics). Use regular bundling for larger logic.

--- a/packages/renoun/src/components/Script.tsx
+++ b/packages/renoun/src/components/Script.tsx
@@ -1,0 +1,247 @@
+import React from 'react'
+
+/** Determines how the script is included in the HTML */
+type ScriptVariants =
+  /** Renders a script tag with the `defer` attribute. */
+  | 'defer'
+  /** Renders a script tag with an async data URL to load the script as soon as possible. */
+  | 'hoist'
+  /** Renders a script tag with the script content inline. */
+  | 'inline'
+
+interface ScriptProps {
+  /** The variant of script to render. Defaults to `defer`. */
+  variant?: ScriptVariants
+
+  /** A nonce for Content Security Policy */
+  nonce?: string
+
+  /**
+   * A promise that resolves to a module with a default export containing the
+   * script content. The script should be contained entirely within the default
+   * export. Only types can be external to the default export.
+   */
+  children: Promise<any>
+}
+
+/** Renders a script tag with the provided script content. */
+export async function Script({
+  variant = 'defer',
+  nonce,
+  children,
+}: ScriptProps) {
+  const script = await children
+  const body = getBody(script.default)
+  if (variant === 'hoist') {
+    const base64 = Buffer.from(body, 'utf8').toString('base64')
+    return (
+      <script
+        nonce={nonce}
+        async
+        src={`data:text/javascript;base64,${base64}`}
+      />
+    )
+  }
+  return <script nonce={nonce} defer={variant === 'defer'} children={body} />
+}
+
+/** Extracts the body of a function as a string. */
+function getBody(fn: Function): string {
+  const string = Function.prototype.toString.call(fn).trim()
+
+  if (string.startsWith('function') || string.startsWith('async function')) {
+    const open = string.indexOf('{', string.indexOf(')'))
+    return open !== -1 ? extractBalancedBlock(string, open) : ''
+  }
+
+  const arrowIndex = findTopLevelArrow(string)
+  if (arrowIndex !== -1) {
+    const brace = string.indexOf('{', arrowIndex)
+    if (brace !== -1) return extractBalancedBlock(string, brace)
+    const expression = string
+      .slice(arrowIndex + 2)
+      .trim()
+      .replace(/^\(|\);?$/g, '')
+    return `void (${expression});`
+  }
+
+  return ''
+}
+
+/** Returns the substring inside the balanced braces that start at `openIndex`. */
+function extractBalancedBlock(source: string, openIndex: number): string {
+  let depth = 1
+  let inSingle = false
+  let inDouble = false
+  let inTemplate = false
+  let escaped = false
+  let inLineComment = false
+  let inBlockComment = false
+  let templateExprDepth = 0
+
+  for (let index = openIndex + 1; index < source.length; index++) {
+    const character = source[index]
+    const prev = source[index - 1]
+    const next = source[index + 1]
+
+    if (inLineComment) {
+      if (character === '\n') inLineComment = false
+      continue
+    }
+    if (inBlockComment) {
+      if (prev === '*' && character === '/') inBlockComment = false
+      continue
+    }
+
+    if (inSingle) {
+      if (!escaped && character === "'") inSingle = false
+      escaped = character === '\\' && !escaped
+      if (character !== '\\') escaped = false
+      continue
+    }
+    if (inDouble) {
+      if (!escaped && character === '"') inDouble = false
+      escaped = character === '\\' && !escaped
+      if (character !== '\\') escaped = false
+      continue
+    }
+    if (inTemplate) {
+      if (!escaped && character === '`' && templateExprDepth === 0) {
+        inTemplate = false
+        continue
+      }
+      if (!escaped && character === '{' && prev === '$') {
+        templateExprDepth++
+        continue
+      }
+      if (!escaped && character === '}' && templateExprDepth > 0) {
+        templateExprDepth--
+        continue
+      }
+      escaped = character === '\\' && !escaped
+      if (character !== '\\') escaped = false
+      continue
+    }
+
+    if (character === '/' && next === '/') {
+      inLineComment = true
+      index++
+      continue
+    }
+    if (character === '/' && next === '*') {
+      inBlockComment = true
+      index++
+      continue
+    }
+
+    if (character === "'") {
+      inSingle = true
+      continue
+    }
+    if (character === '"') {
+      inDouble = true
+      continue
+    }
+    if (character === '`') {
+      inTemplate = true
+      templateExprDepth = 0
+      continue
+    }
+
+    if (character === '{') {
+      depth++
+      continue
+    }
+    if (character === '}') {
+      depth--
+      if (depth === 0) return source.slice(openIndex + 1, index)
+      continue
+    }
+  }
+  return ''
+}
+
+/** Finds the first top-level `=>` (ignoring strings/comments/templates). */
+function findTopLevelArrow(source: string): number {
+  let inSingle = false
+  let inDouble = false
+  let inTemplate = false
+  let escaped = false
+  let inLineComment = false
+  let inBlockComment = false
+  let templateExprDepth = 0
+
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index]
+    const prev = source[index - 1]
+    const next = source[index + 1]
+
+    if (inLineComment) {
+      if (character === '\n') inLineComment = false
+      continue
+    }
+    if (inBlockComment) {
+      if (prev === '*' && character === '/') inBlockComment = false
+      continue
+    }
+
+    if (inSingle) {
+      if (!escaped && character === "'") inSingle = false
+      escaped = character === '\\' && !escaped
+      if (character !== '\\') escaped = false
+      continue
+    }
+    if (inDouble) {
+      if (!escaped && character === '"') inDouble = false
+      escaped = character === '\\' && !escaped
+      if (character !== '\\') escaped = false
+      continue
+    }
+
+    if (inTemplate) {
+      if (!escaped && character === '`' && templateExprDepth === 0) {
+        inTemplate = false
+        continue
+      }
+      if (!escaped && character === '{' && prev === '$') {
+        templateExprDepth++
+        continue
+      }
+      if (!escaped && character === '}' && templateExprDepth > 0) {
+        templateExprDepth--
+        continue
+      }
+      escaped = character === '\\' && !escaped
+      if (character !== '\\') escaped = false
+      continue
+    }
+
+    if (character === '/' && next === '/') {
+      inLineComment = true
+      index++
+      continue
+    }
+    if (character === '/' && next === '*') {
+      inBlockComment = true
+      index++
+      continue
+    }
+
+    if (character === "'") {
+      inSingle = true
+      continue
+    }
+    if (character === '"') {
+      inDouble = true
+      continue
+    }
+    if (character === '`') {
+      inTemplate = true
+      templateExprDepth = 0
+      continue
+    }
+
+    if (character === '=' && next === '>') return index
+  }
+  return -1
+}

--- a/packages/renoun/src/components/index.ts
+++ b/packages/renoun/src/components/index.ts
@@ -43,4 +43,5 @@ export {
   type NavigationProps,
   type NavigationComponents,
 } from './Navigation.js'
+export { Script } from './Script.js'
 export { Sponsors } from './Sponsors.js'


### PR DESCRIPTION
Adds a `Script` component that lets you author a client-side script using a normal source file that is then injected into HTML either inline, deferred, or as a hoisted data URL. This is useful for small scripts like analytics snippets, theme preferences, feature flags, or bootstrapping navigation active states.

```tsx path="app/page.tsx"
import { Script } from 'renoun'

export default function RootLayout({
  children,
}: {
  children: React.ReactNode
}) {
  return (
    <html>
      <head>
        <Script>{import('./table-of-contents-script.ts')}</Script>
      </head>
      <body>{children}</body>
    </html>
  )
}
```